### PR TITLE
PingInterval middleware

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -10,7 +10,7 @@
 
  * Http & Tick middleware support (@sirn-se)
  * PingInterval middleware for heartbeat functionality (@sirn-se)
- * Connection get/set meta functions
+ * Connection get/set meta functions (@sirn-se)
  * Fixing various typos (@UksusoFF, @sirn-se)
  * Remove unused code and documentation (@sirn-se)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8,8 +8,10 @@
 
 ### `2.1.0`
 
- * Http & Tick middleware support
- * Remove unused code and documentation
+ * Http & Tick middleware support (@sirn-se)
+ * PingInterval middleware for heartbeat functionality (@sirn-se)
+ * Fixing various typos (@UksusoFF, @sirn-se)
+ * Remove unused code and documentation (@sirn-se)
 
 ## `v2.0`
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -10,6 +10,7 @@
 
  * Http & Tick middleware support (@sirn-se)
  * PingInterval middleware for heartbeat functionality (@sirn-se)
+ * Connection get/set meta functions
  * Fixing various typos (@UksusoFF, @sirn-se)
  * Remove unused code and documentation (@sirn-se)
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -20,7 +20,7 @@ Base your patch on corresponding version branch, and target that version branch 
 | [`2.0`](https://github.com/sirn-se/websocket-php/tree/2.0.0) | `v2.0-main` | `^8.0` | Bug fixes only |
 | [`1.7`](https://github.com/sirn-se/websocket-php/tree/1.7.0) | `v1.7-master` | `^7.4\|^8.0` | Bug fixes only |
 | [`1.6`](https://github.com/sirn-se/websocket-php/tree/1.6.0) | `v1.6-master` | `^7.4\|^8.0` | Not supported |
-| [`1.5`](https://github.com/sirn-se/websocket-php/tree/1.5.0) | `v1.5-master` | `^7.4\|^8.0` | Not supported |
+| [`1.5`](https://github.com/sirn-se/websocket-php/tree/1.5.0) | - | `^7.4\|^8.0` | Not supported |
 | [`1.4`](https://github.com/sirn-se/websocket-php/tree/1.4.0) | - | `^7.1` | Not supported |
 | [`1.3`](https://github.com/sirn-se/websocket-php/tree/1.3.0) | - | `^5.4\|^7.0` | Not supported |
 | [`1.2`](https://github.com/sirn-se/websocket-php/tree/1.2.0) | - | - | Not supported |

--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -3,15 +3,7 @@
 # Websocket: Middleware
 
 Both [Client](Client.md) and [Server](Server.md) support adding middlewares.
-All added middlewares will be called when a [Message](Message.md) is sent and/or received.
-
-## Standard operation
-
-These two middlewares provide standard operability according to WebSocket protocol,
-and should be added unless you write your own implementation of close and ping/pong handling.
-
-* `CloseHandler` - Automatically acts on incoming and outgoing Close requests, as specified in WebSocket protocol
-* `PingResponder` - Responds with Pong message when receiving a Ping message, as specified in WebSocket protocol
+All added middlewares will be called when certain actions are performed.
 
 Add middlewares by calling the `addMiddleware` method.
 
@@ -27,48 +19,86 @@ $server
     ;
 ```
 
-## The CloseHandler middleware
+## Standard middlewares
+
+These two middlewares provide standard operability according to WebSocket protocol,
+and should be added unless you write your own implementation of close and ping/pong handling.
+
+* `CloseHandler` - Automatically acts on incoming and outgoing Close requests, as specified in WebSocket protocol
+* `PingResponder` - Responds with Pong message when receiving a Ping message, as specified in WebSocket protocol
+
+## Optional middlewares
+
+These middlewares are included in library and can be added to provide additional functionality.
+
+* `PingInterval` - Used to automatically send Ping messages at specified interval
+* `Callback` - Apply sprcified callback function on certain actions
+
+## Middleware descriptions
+
+Descriptiopn of included middlewares.
+
+### The CloseHandler middleware
 
 * When a Close message is received, CloseHandler will respond with a Close confirmation message
 * When a Close confirmation message is received, CloseHandler will close the connection
 * When a Close message is sent, CloseHandler will block further messages from being sent
 
-## The PingResponder middleware
+```php
+$client_or_server->addMiddleware(new WebSocket\Middleware\CloseHandler());
+```
+
+### The PingResponder middleware
 
 * When a Ping message is received, PingResponder will respond with a Pong message
 
-## The Callback middleware
+```php
+$client_or_server->addMiddleware(new WebSocket\Middleware\PingResponder());
+```
+
+### The PingInterval middleware
+
+* Sends Ping messages on Connection at interval, typically used as "heartbeat" to keep connection open
+* If `interval` is not specified, it will use connection timeout configuration as interval
+
+```php
+$client_or_server->addMiddleware(new WebSocket\Middleware\PingInterval(interval: 10));
+```
+
+### The Callback middleware
 
 This middleware will apply callback functions when a message is sent and/or received.
 
 ```php
 $client_or_server
     ->addMiddleware(new WebSocket\Middleware\Callback(
-        incoming: function (WebSocket\Middleware\ProcessStack $stack, WebSocket\Connection $connection) {
+        incoming: function (WebSocket\Middleware\ProcessStack $stack, WebSocket\Connection $connection): WebSocket\Message\Message {
             $message = $stack->handleIncoming(); // Get incoming message from next middleware
             $message->setContent("Changed message");
             return $message;
         },
-        outgoing: function (WebSocket\Middleware\ProcessStack $stack, WebSocket\Connection $connection, WebSocket\Message\Message $message) {
+        outgoing: function (WebSocket\Middleware\ProcessStack $stack, WebSocket\Connection $connection, WebSocket\Message\Message $message): WebSocket\Message\Message {
             $message->setContent('Changed message');
             $message = $stack->handleOutgoing($message); // Forward outgoing message to next middleware
             return $message;
         },
-        httpIncoming: function (WebSocket\Middleware\ProcessHttpStack $stack, WebSocket\Connection $connection) {
+        httpIncoming: function (WebSocket\Middleware\ProcessHttpStack $stack, WebSocket\Connection $connection): WebSocket\Http\Message {
             $message = $stack->handleHttpIncoming(); // Get incoming message from next middleware
             return $message;
         },
-        httpOutgoing: function (WebSocket\Middleware\ProcessHttpStack $stack, WebSocket\Connection $connection, WebSocket\Message\Message $message) {
+        httpOutgoing: function (WebSocket\Middleware\ProcessHttpStack $stack, WebSocket\Connection $connection, WebSocket\Http\Message $message): WebSocket\Http\Message {
             $message = $stack->handleHttpOutgoing($message); // Forward outgoing message to next middleware
             return $message;
         },
-        tick: function (WebSocket\Middleware\ProcessTickStack $stack, WebSocket\Connection $connection) {
+        tick: function (WebSocket\Middleware\ProcessTickStack $stack, WebSocket\Connection $connection): void {
             $stack->handleTick(); // Forward tick to next middleware
         }
     ));
 ```
 
-The callback functions **MUST** return a [Message](Message.md) instance or a HTTP request/response message respectively..
+* The `incoming` and `outgoing` callbacks **MUST** return a [Message](Message.md) instance
+* The `httpIncoming` and `httpOutgoing` callbacks **MUST** return a HTTP request/response instance respectively
+* The `tick` callback returns nothing
 
 The `handleIncoming`, `handleOutgoing`, `handleHttpIncoming`, `handleHttpOutgoing` and `handleTick` methods will pass initiative further down the middleware stack.
 

--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -32,7 +32,7 @@ and should be added unless you write your own implementation of close and ping/p
 These middlewares are included in library and can be added to provide additional functionality.
 
 * `PingInterval` - Used to automatically send Ping messages at specified interval
-* `Callback` - Apply sprcified callback function on certain actions
+* `Callback` - Apply provided callback function on specified actions
 
 ## Middleware descriptions
 
@@ -67,7 +67,7 @@ $client_or_server->addMiddleware(new WebSocket\Middleware\PingInterval(interval:
 
 ### The Callback middleware
 
-This middleware will apply callback functions when a message is sent and/or received.
+This middleware will apply callback functions on certain actions.
 
 ```php
 $client_or_server
@@ -166,11 +166,6 @@ interface WebSocket\Middleware\ProcessHttpOutgoingInterface extends WebSocket\Mi
 A middleware that wants to handle Tick operation **MUST** implement the `ProcessTickInterface`.
 
 ```php
-interface ProcessTickInterface extends MiddlewareInterface
-{
-    public function processTick(ProcessTickStack $stack, Connection $connection): void;
-}
-
 interface WebSocket\Middleware\ProcessTickInterface extends WebSocket\Middleware\MiddlewareInterface
 {
     public function processTick(

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -201,5 +201,11 @@ $connection->getHandshakeRequest();
 
 // Get the Response server sent during handshake procedure
 $connection->getHandshakeResponse();
-```
 
+// Trigger a tick event on connection
+$connection->tick();
+
+// Get and set associated meta data on connection
+$connection->setMeta('myMetaData', $anything);
+$connection->getMeta('myMetaData');
+```

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -61,6 +61,7 @@ class Connection implements LoggerAwareInterface, Stringable
     private $remoteName;
     private $handshakeRequest;
     private $handshakeResponse;
+    private $meta = [];
 
 
     /* ---------- Magic methods ------------------------------------------------------------------------------------ */
@@ -242,6 +243,26 @@ class Connection implements LoggerAwareInterface, Stringable
     public function getRemoteName(): string|null
     {
         return $this->remoteName;
+    }
+
+    /**
+     * Set meta value on connection.
+     * @param string $key Meta key
+     * @param mixed $value Meta value
+     */
+    public function setMeta(string $key, mixed $value): void
+    {
+        $this->meta[$key] = $value;
+    }
+
+    /**
+     * Set meta value on connection.
+     * @param string $key Meta key
+     * @return mixed Meta value
+     */
+    public function getMeta(string $key): mixed
+    {
+        return $this->meta[$key] ?? null;
     }
 
     /**

--- a/src/Middleware/PingInterval.php
+++ b/src/Middleware/PingInterval.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Copyright (C) 2014-2023 Textalk and contributors.
+ *
+ * This file is part of Websocket PHP and is free software under the ISC License.
+ * License text: https://raw.githubusercontent.com/sirn-se/websocket-php/master/COPYING.md
+ */
+
+namespace WebSocket\Middleware;
+
+use Psr\Log\{
+    LoggerAwareInterface,
+    LoggerAwareTrait
+};
+use Stringable;
+use WebSocket\Connection;
+use WebSocket\Message\{
+    Close,
+    Message
+};
+
+/**
+ * WebSocket\Middleware\PingInterval class.
+ * Handles close procedure.
+ */
+class PingInterval implements LoggerAwareInterface, ProcessOutgoingInterface, ProcessTickInterface, Stringable
+{
+    use LoggerAwareTrait;
+
+    private $interval;
+
+    public function __construct(int|null $interval = null)
+    {
+        $this->interval = $interval;
+    }
+
+    public function processOutgoing(ProcessStack $stack, Connection $connection, Message $message): Message
+    {
+        $this->setNext($connection); // Update timestamp for next ping
+        return $stack->handleOutgoing($message);
+    }
+
+    public function processTick(ProcessTickStack $stack, Connection $connection): void
+    {
+        // Push if time exceeds timestamp for next ping
+        if ($connection->isWritable() && time() >= $this->getNext($connection)) {
+            $this->logger->debug("[ping-interval] Auto-pushing ping");
+            $connection->ping();
+            $this->setNext($connection); // Update timestamp for next ping
+        }
+        $stack->handleTick();
+    }
+
+    public function __toString(): string
+    {
+        return get_class($this);
+    }
+
+    private function getNext(Connection $connection): int
+    {
+        return $connection->getMeta('pingInterval.next') ?? $this->setNext($connection);
+    }
+
+    private function setNext(Connection $connection): int
+    {
+        $next = time() + ($this->interval ?? $connection->getTimeout());
+        $connection->setMeta('pingInterval.next', $next);
+        return $next;
+    }
+}

--- a/src/Middleware/PingInterval.php
+++ b/src/Middleware/PingInterval.php
@@ -16,7 +16,7 @@ use Psr\Log\{
 use Stringable;
 use WebSocket\Connection;
 use WebSocket\Message\{
-    Close,
+    Ping,
     Message
 };
 
@@ -46,7 +46,7 @@ class PingInterval implements LoggerAwareInterface, ProcessOutgoingInterface, Pr
         // Push if time exceeds timestamp for next ping
         if ($connection->isWritable() && time() >= $this->getNext($connection)) {
             $this->logger->debug("[ping-interval] Auto-pushing ping");
-            $connection->ping();
+            $connection->send(new Ping());
             $this->setNext($connection); // Update timestamp for next ping
         }
         $stack->handleTick();

--- a/tests/suites/connection/ConnectionTest.php
+++ b/tests/suites/connection/ConnectionTest.php
@@ -70,6 +70,11 @@ class ConnectionTest extends TestCase
         $this->assertEquals('', $connection->getName());
         $this->assertEquals('', $connection->getRemoteName());
         $this->assertEquals('Connection()', "{$connection}");
+        $connection->tick();
+        $connection->setMeta('test.meta.1', 'meta.data.1');
+        $connection->setMeta('test.meta.2', 'meta.data.2');
+        $this->assertEquals('meta.data.1', $connection->getMeta('test.meta.1'));
+        $this->assertEquals('meta.data.2', $connection->getMeta('test.meta.2'));
 
         $this->expectSocketStreamSetTimeout();
         $this->assertSame($connection, $connection->setTimeout(10));

--- a/tests/suites/middleware/PingIntervalTest.php
+++ b/tests/suites/middleware/PingIntervalTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Phrity\Net\Mock\SocketStream;
 use Phrity\Net\Mock\Stack\ExpectSocketStreamTrait;
 use WebSocket\Connection;
-use WebSocket\Message\Ping;
 use WebSocket\Middleware\PingInterval;
 
 /**
@@ -56,9 +55,13 @@ class PingIntervalTest extends TestCase
         $this->expectSocketStreamIsWritable();
         $connection->tick();
 
+        // Next tick should not trigger ping
+        $this->expectSocketStreamIsWritable();
+        $connection->tick();
+
         sleep(1); // Simulate inactivity
 
-        // This tick should now trigger auto-ping
+        // This tick should now trigger ping
         $this->expectSocketStreamIsWritable();
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals(base64_decode('iQA='), $params[0]);

--- a/tests/suites/middleware/PingIntervalTest.php
+++ b/tests/suites/middleware/PingIntervalTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Copyright (C) 2014-2023 Textalk and contributors.
+ *
+ * This file is part of Websocket PHP and is free software under the ISC License.
+ * License text: https://raw.githubusercontent.com/sirn-se/websocket-php/master/COPYING.md
+ */
+
+declare(strict_types=1);
+
+namespace WebSocket\Test\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Phrity\Net\Mock\SocketStream;
+use Phrity\Net\Mock\Stack\ExpectSocketStreamTrait;
+use WebSocket\Connection;
+use WebSocket\Message\Ping;
+use WebSocket\Middleware\PingInterval;
+
+/**
+ * Test case for WebSocket\Middleware\PingIntervalTest
+ */
+class PingIntervalTest extends TestCase
+{
+    use ExpectSocketStreamTrait;
+
+    public function setUp(): void
+    {
+        error_reporting(-1);
+        $this->setUpStack();
+    }
+
+    public function tearDown(): void
+    {
+        $this->tearDownStack();
+    }
+
+    public function testPingInterval(): void
+    {
+        $temp = tmpfile();
+
+        $middleware = new PingInterval(1);
+        $this->assertEquals('WebSocket\Middleware\PingInterval', "{$middleware}");
+
+        $this->expectSocketStream();
+        $this->expectSocketStreamGetMetadata();
+        $stream = new SocketStream($temp);
+
+        $this->expectSocketStreamGetLocalName();
+        $this->expectSocketStreamGetRemoteName();
+        $connection = new Connection($stream, false, false);
+        $connection->addMiddleware($middleware);
+
+        // First tick set interval
+        $this->expectSocketStreamIsWritable();
+        $connection->tick();
+
+        sleep(1); // Simulate inactivity
+
+        // This tick should now trigger auto-ping
+        $this->expectSocketStreamIsWritable();
+        $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
+            $this->assertEquals(base64_decode('iQA='), $params[0]);
+        });
+        $connection->tick();
+
+        $this->expectSocketStreamIsConnected();
+        $this->expectSocketStreamClose();
+        unset($stream);
+    }
+}


### PR DESCRIPTION
Adds `PingInterval` middleware, can be used as "heartbeat" to keep connection open by regularly sned Ping messages.