### PR TITLE
Add supported protocols to server and client

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -73,12 +73,15 @@ $client
         ],
     ])
     // Add header to handshake request
-    ->addHeader("Sec-WebSocket-Protocol", "soap")
+    ->addHeader("my-header", "header-value")
+    // Add requested protocol
+    ->setSubProtocol("soap")
     ;
 
 // Get current settings
 echo "timeout:      {$client->getTimeout()}s\n";
 echo "frame size:   {$client->getFrameSize()}b\n";
+echo "protocol:      {$client->getSubProtocol()}\n";
 echo "running:      {$client->isRunning()}\n";
 ```
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -42,14 +42,17 @@ $server
     ->setTimeout(300)
     // Specify frame size in bytes (default 4096 bytes)
     ->setFrameSize(1024)
+    // Specify which protocols are supported (default empty)
+    ->setSupportedSubProtocols(['soapV1', 'soapV2'])
     ;
 
-echo "port:         {$server->getPort()}\n";
-echo "scheme:       {$server->getScheme()}\n";
-echo "timeout:      {$server->getTimeout()}s\n";
-echo "frame size:   {$server->getFrameSize()}b\n";
-echo "running:      {$server->isRunning()}\n";
-echo "connections:  {$server->getConnectionCount()}\n";
+echo "port:                 {$server->getPort()}\n";
+echo "scheme:               {$server->getScheme()}\n";
+echo "timeout:              {$server->getTimeout()}s\n";
+echo "frame size:           {$server->getFrameSize()}b\n";
+echo "running:              {$server->isRunning()}\n";
+echo "connections:          {$server->getConnectionCount()}\n";
+echo "supported protocols:" .  implode(', ', $server->getSupportedSubProtocols()) ."\n";
 ```
 
 ## Middlewares

--- a/src/Client.php
+++ b/src/Client.php
@@ -67,6 +67,7 @@ class Client implements LoggerAwareInterface, Stringable
     private $middlewares = [];
     private $streams;
     private $running = false;
+    private $subProtocol;
 
 
     /* ---------- Magic methods ------------------------------------------------------------------------------------ */
@@ -220,6 +221,24 @@ class Client implements LoggerAwareInterface, Stringable
         return $this;
     }
 
+    /**
+     * @return string
+     */
+    public function getSubProtocol(): string
+    {
+        return $this->subProtocol;
+    }
+
+    /**
+     * @param string $subProtocol
+     * @return Client
+     */
+    public function setSubProtocol(string $subProtocol): self
+    {
+        $this->subProtocol = $subProtocol;
+
+        return $this;
+    }
 
     /* ---------- Messaging operations ----------------------------------------------------------------------------- */
 
@@ -484,6 +503,10 @@ class Client implements LoggerAwareInterface, Stringable
             ->withHeader('Upgrade', 'websocket')
             ->withHeader('Sec-WebSocket-Key', $key)
             ->withHeader('Sec-WebSocket-Version', '13');
+
+        if ($this->subProtocol) {
+            $request = $request->withHeader('Sec-WebSocket-Protocol', $this->subProtocol);
+        }
 
         // Handle basic authentication.
         if ($userinfo = $this->socketUri->getUserInfo()) {

--- a/tests/suites/client/ConfigTest.php
+++ b/tests/suites/client/ConfigTest.php
@@ -195,6 +195,26 @@ class ConfigTest extends TestCase
         unset($client);
     }
 
+    public function testProtocolOption(): void
+    {
+        $this->expectStreamFactory();
+        $client = new Client('ws://localhost:8000/my/mock/path');
+        $client->setStreamFactory(new StreamFactory());
+        $client->setSubProtocol('soap');
+
+        $this->expectWsClientConnect();
+        $this->expectWsClientPerformHandshake(
+            'localhost:8000',
+            '/my/mock/path',
+            "Sec-WebSocket-Protocol: soap\r\n"
+        );
+        $client->connect();
+
+        $this->expectSocketStreamIsConnected();
+        $this->expectSocketStreamClose();
+        unset($client);
+    }
+
     public function testHeadersOption(): void
     {
         $this->expectStreamFactory();

--- a/tests/suites/server/ConfigTest.php
+++ b/tests/suites/server/ConfigTest.php
@@ -114,7 +114,7 @@ class ConfigTest extends TestCase
         $this->assertSame($server, $server->setTimeout(300));
         $this->assertSame($server, $server->setFrameSize(64));
         $this->assertSame($server, $server->addMiddleware(new Callback()));
-        $this->assertSame($server, $server->setSupportedSubProtocols(['soap']));
+        $this->assertSame($server, $server->addSupportedSubProtocol('soap'));
 
         $this->assertEquals('WebSocket\Server(ssl://0.0.0.0:9000)', "{$server}");
         $this->assertEquals(300, $server->getTimeout());

--- a/tests/suites/server/ConfigTest.php
+++ b/tests/suites/server/ConfigTest.php
@@ -63,6 +63,7 @@ class ConfigTest extends TestCase
         $this->assertEquals('tcp', $server->getScheme());
         $this->assertFalse($server->isRunning());
         $this->assertEquals(0, $server->getConnectionCount());
+        $this->assertEmpty($server->getSupportedSubProtocols());
 
         $this->expectWsServerSetup(scheme: 'tcp', port: 8000);
         $this->expectStreamCollectionWaitRead()->addAssert(function ($method, $params) {
@@ -113,6 +114,7 @@ class ConfigTest extends TestCase
         $this->assertSame($server, $server->setTimeout(300));
         $this->assertSame($server, $server->setFrameSize(64));
         $this->assertSame($server, $server->addMiddleware(new Callback()));
+        $this->assertSame($server, $server->setSupportedSubProtocols(['soap']));
 
         $this->assertEquals('WebSocket\Server(ssl://0.0.0.0:9000)', "{$server}");
         $this->assertEquals(300, $server->getTimeout());
@@ -121,6 +123,7 @@ class ConfigTest extends TestCase
         $this->assertEquals('ssl', $server->getScheme());
         $this->assertFalse($server->isRunning());
         $this->assertEquals(1, $server->getConnectionCount());
+        $this->assertEquals(['soap'], $server->getSupportedSubProtocols());
 
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamClose();


### PR DESCRIPTION
We needed a bit more control over the handshake. Since it is quite common for websockets to adhere to a specific protocol I chose to specifically implement this. In the `Client` it was already possible to set a protocol in the handshake header, but the `Server` had no such way.

With this update it is now possible to define which protocols are supported by the server, which will be validated and replied to the client during the handshake.