### PR TITLE
Allow repeated headers when pulling HTTP messages

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,10 @@
 
  > PHP version `^8.0`
 
+### `2.1.2`
+
+ * Allow repeated headers when pulling HTTP messages (@sirn-se)
+
 ### `2.1.1`
 
  * Fix issue with falsy but valid HTTP headers (@axklim)

--- a/src/Http/HttpHandler.php
+++ b/src/Http/HttpHandler.php
@@ -85,7 +85,7 @@ class HttpHandler implements LoggerAwareInterface, Stringable
         foreach ($headers as $header) {
             $parts = explode(':', $header, 2);
             if (count($parts) == 2) {
-                $message = $message->withHeader($parts[0], $parts[1]);
+                $message = $message->withAddedHeader($parts[0], $parts[1]);
             }
         }
         if ($message instanceof Request) {

--- a/src/Middleware/Callback.php
+++ b/src/Middleware/Callback.php
@@ -16,10 +16,7 @@ use Psr\Log\{
 };
 use Stringable;
 use WebSocket\Connection;
-use WebSocket\Http\{
-    HttpHandler,
-    Message as HttpMessage
-};
+use WebSocket\Http\Message as HttpMessage;
 use WebSocket\Message\Message;
 use WebSocket\Trait\StringableTrait;
 


### PR DESCRIPTION
If HTTP message included repeated headers, only the last was added to message.
Now adds all headers.

Also removing unused `use` statement.