### PR TITLE
Allow additional content in Connection header during handshake

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,10 @@
 
  > PHP version `^8.0`
 
+### `2.1.3`
+
+ * Allow additional content in Connection header during handshake (@sirn-se)
+
 ### `2.1.2`
 
  * Allow repeated headers when pulling HTTP messages (@sirn-se)

--- a/src/Server.php
+++ b/src/Server.php
@@ -436,7 +436,7 @@ class Server implements LoggerAwareInterface, Stringable
                 );
             }
             $connectionHeader = trim($request->getHeaderLine('Connection'));
-            if (strtolower($connectionHeader) != 'upgrade') {
+            if (!str_contains('upgrade', strtolower($connectionHeader))) {
                 throw new HandshakeException(
                     "Handshake request with invalid Connection header: '{$connectionHeader}'",
                     $response->withStatus(426)


### PR DESCRIPTION
According to [RFC](https://datatracker.ietf.org/doc/html/rfc6455#section-4.1), the `Connection` header MAY include additional content, but MUST include the "Upgrade" keyword. 

> The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token.

Issue #39 got "keep-alive, Upgrade" which would be valid, but caused an error in current version.

Closing #39 