### PR TITLE
Fix basic auth to support non-ascii characters

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -501,8 +501,18 @@ class Client implements LoggerAwareInterface, Stringable
             ->withHeader('Sec-WebSocket-Version', '13');
 
         // Handle basic authentication.
-        if ($userinfo = $uri->getUserInfo()) {
-            $request = $request->withHeader('Authorization', 'Basic ' . base64_encode($userinfo));
+        $components = $uri->getComponents();
+        if (array_key_exists('user', $components)) {
+            $user = urldecode($components['user']);
+
+            if (array_key_exists('pass', $components)) {
+                $pass = $components['pass'];
+                $credentials = urldecode($user) . ':' . urldecode($pass);
+            } else {
+                $credentials = urldecode($user);
+            }
+
+            $request = $request->withHeader('Authorization', 'Basic ' . base64_encode($credentials));
         }
 
         // Add and override with headers.


### PR DESCRIPTION
Fixes https://github.com/sirn-se/websocket-php/issues/56

Ideally, upstream https://github.com/sirn-se/phrity-net-uri would have methods to get URL decoded username/password, but for the time being, the following should solve the authentication issue.