### PR TITLE
PHP 8.3 Fatal error fix

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -106,15 +106,13 @@ class Client implements LoggerAwareInterface, Stringable
     /**
      * Set logger.
      * @param Psr\Log\LoggerInterface $logger Logger implementation
-     * @return self.
      */
-    public function setLogger(LoggerInterface $logger): self
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
         if ($this->connection) {
             $this->connection->setLogger($this->logger);
         }
-        return $this;
     }
 
     /**


### PR DESCRIPTION
On PHP 8.3:

Fatal error: A void function must not return a value in /var/www/backend/vendor/phrity/websocket/src/Client.php on line 118
Handled by shutdown function. Fatal error #64: A void function must not return a value on /var/www/backend/vendor/phrity/websocket/src/Client.php:118