### PR TITLE
Fixing dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phrity/net-uri": "^1.2",
         "phrity/net-stream": "^1.2",
         "phrity/util-errorhandler": "^1.0",
-        "psr/http-message": "^1.0 | ^2.0",
+        "psr/http-message": "^1.1 | ^2.0",
         "psr/log": "^1.0 | ^2.0 | ^3.0"
     },
     "require-dev": {

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,10 @@
 
  > PHP version `^7.4|^8.0`
 
+### `1.7.3`
+
+ * Fix dependency `psr/http-message` (@sirn-se)
+
 ### `1.7.2`
 
  * PSR compliance `psr/log v3` `psr/http-message v2` (@sirn-se)


### PR DESCRIPTION
Repo do not work with `psr/http-message v1.0`, setting `v1.1` as minimum.