### PR TITLE
Additional documentation

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -13,6 +13,7 @@
  * Server `setMaxConnections(int|null)` (@sirn-se)
  * Server `shutdown()` orderly close server (@sirn-se)
  * `phrity/net-uri v2.1` for URI decoding (@sirn-se)
+ * Public class synopsis added to documentation (@sirn-se)
 
 ### `3.0.0`
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -24,8 +24,8 @@ Base your patch on corresponding version branch, and target that version branch 
 
 | Version | Branch | PHP | Status |
 | --- | --- | --- | --- |
-| [`3.1`](https://github.com/sirn-se/websocket-php/tree/3.1.0) | `v3.1-main` | `^8.1` | Under development |
-| [`3.0`](https://github.com/sirn-se/websocket-php/tree/3.0.0) | `v3.0-main` | `^8.1` | Current version |
+| [`3.1`](https://github.com/sirn-se/websocket-php/tree/3.1.0) | `v3.1-main` | `^8.1` | Current version |
+| [`3.0`](https://github.com/sirn-se/websocket-php/tree/3.0.0) | `v3.0-main` | `^8.1` | Bug fixes only |
 | [`2.2`](https://github.com/sirn-se/websocket-php/tree/2.2.0) | `v2.2-main` | `^8.0` | Bug fixes only |
 | [`2.1`](https://github.com/sirn-se/websocket-php/tree/2.1.0) | - | `^8.0` | Not supported |
 | [`2.0`](https://github.com/sirn-se/websocket-php/tree/2.0.0) | - | `^8.0` | Not supported |


### PR DESCRIPTION
Ready for `3.1` release.