### PR TITLE
Fix missing return statement in server shutdown method

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,12 @@
 
  > PHP version `^8.1`
 
+### `3.2.1`
+
+ * Fix missing return statement in server shutdown method (@sirn-se)
+ * Unit tests for php 8.5 (@sirn-se)
+ * Documentation broken links fixed (@sirn-se)
+
 ### `3.2.0`
 
  * Server `setContext()` method (@sirn-se)

--- a/src/Server.php
+++ b/src/Server.php
@@ -419,6 +419,7 @@ class Server implements LoggerAwareInterface, Stringable
         $this->logger->info('[server] Shutting down');
         if ($this->getConnectionCount() == 0) {
             $this->disconnect();
+            return;
         }
         // Store and reset settings, lock new connections, reset listeners
         $max = $this->maxConnections;


### PR DESCRIPTION
If no clients currently connected, code should not wait for close acks.

Closes #87 