### PR TITLE
Handle invalid server requests

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9,6 +9,7 @@
 ### `3.2.1`
 
  * Fix missing return statement in server shutdown method (@sirn-se)
+ * Handle invalid server requests (@sirn-se)
  * Unit tests for php 8.5 (@sirn-se)
  * Documentation broken links fixed (@sirn-se)
 

--- a/tests/mock/MockStreamTrait.php
+++ b/tests/mock/MockStreamTrait.php
@@ -95,9 +95,28 @@ trait MockStreamTrait
         $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
             $this->assertEquals(1024, $params[0]);
         })->setReturn(function (array $params) {
+            return "HTTP/1.1 101 Switching Protocols\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
+            return "Upgrade: websocket\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
+            return "Connection: Upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
             $ws_key_res = base64_encode(pack('H*', sha1($this->last_ws_key . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')));
-            return "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade"
-            . "\r\nSec-WebSocket-Accept: {$ws_key_res}\r\n\r\n";
+            return "Sec-WebSocket-Accept: {$ws_key_res}\r\n\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
+            return "\r\n";
         });
     }
 
@@ -148,15 +167,54 @@ trait MockStreamTrait
     private function expectWsServerPerformHandshake(
         string $host = 'localhost:8000',
         string $path = '/my/mock/path',
-        string $headers = ''
+        array $headers = []
     ): void {
         $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
             $this->assertEquals(1024, $params[0]);
-        })->setReturn(function (array $params) use ($host, $path, $headers) {
-            return "GET {$path} HTTP/1.1\r\nHost: {$host}\r\nUser-Agent: websocket-client-php\r\n"
-            . "Connection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n"
-            . "Sec-WebSocket-Version: 13"
-            . "\r\n{$headers}\r\n";
+        })->setReturn(function (array $params) use ($path) {
+            return "GET {$path} HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) use ($host) {
+            return "Host: {$host}\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
+            return "User-Agent: websocket-client-php\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
+            return "Connection: Upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
+            return "Upgrade: websocket\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
+            return "Sec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n";
+        });
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
+            return "Sec-WebSocket-Version: 13\r\n";
+        });
+        foreach ($headers as $header) {
+            $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+                $this->assertEquals(1024, $params[0]);
+            })->setReturn(function (array $params) use ($header) {
+                return "{$header}\r\n";
+            });
+        }
+        $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
+            $this->assertEquals(1024, $params[0]);
+        })->setReturn(function (array $params) {
+            return "\r\n";
         });
         $this->expectSocketStreamWrite()->addAssert(function (string $method, array $params): void {
             $expect = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"

--- a/tests/suites/client/HandshakeTest.php
+++ b/tests/suites/client/HandshakeTest.php
@@ -110,7 +110,10 @@ class HandshakeTest extends TestCase
         $this->expectWsClientConnect();
         $this->expectSocketStreamWrite();
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 200 OK\r\n\r\n";
+            return "HTTP/1.1 200 OK\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectException(HandshakeException::class);
         $this->expectExceptionMessage('Invalid status code 200.');
@@ -130,7 +133,13 @@ class HandshakeTest extends TestCase
         $this->expectWsClientConnect();
         $this->expectSocketStreamWrite();
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nInvalid upgrade\r\n\r\n";
+            return "HTTP/1.1 101 Switching Protocols\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Upgrade: websocket\r\nInvalid upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectException(HandshakeException::class);
         $this->expectExceptionMessage('Connection to \'ws://localhost:8000/my/mock/path\' failed');
@@ -150,8 +159,16 @@ class HandshakeTest extends TestCase
         $this->expectWsClientConnect();
         $this->expectSocketStreamWrite();
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
-                . "Sec-WebSocket-Accept: BAD_KEY\r\n\r\n";
+            return "HTTP/1.1 101 Switching Protocols\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Upgrade: websocket\r\nInvalid upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Accept: BAD_KEY\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectException(HandshakeException::class);
         $this->expectExceptionMessage('Server sent bad upgrade response');

--- a/tests/suites/connection/ConnectionTest.php
+++ b/tests/suites/connection/ConnectionTest.php
@@ -150,7 +150,13 @@ class ConnectionTest extends TestCase
         $connection->pushHttp($request);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 200 OK\r\nHost: test.com\r\n\r\n";
+            return "HTTP/1.1 200 OK\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: test.com\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $response = $connection->pullHttp();
         $this->assertInstanceOf(Response::class, $response);

--- a/tests/suites/http/HttpHandlerTest.php
+++ b/tests/suites/http/HttpHandlerTest.php
@@ -104,7 +104,22 @@ class HttpHandlerTest extends TestCase
         $this->assertInstanceOf(HttpHandler::class, $handler);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET /a/path?a=b HTTP/1.1\r\nA: \r\nA: 0\r\nA: B\r\nHost: test.com:123\r\n\r\n";
+            return "GET /a/path?a=b HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "A: \r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "A: 0\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "A: B\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: test.com:123\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $request = $handler->pull();
         $this->assertInstanceOf(ServerRequest::class, $request);
@@ -157,7 +172,13 @@ class HttpHandlerTest extends TestCase
         $this->assertInstanceOf(HttpHandler::class, $handler);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 200 OK\r\nHost: test.com:123\r\n\r\n";
+            return "HTTP/1.1 200 OK\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: test.com:123\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $response = $handler->pull();
         $this->assertInstanceOf(Response::class, $response);
@@ -179,7 +200,7 @@ class HttpHandlerTest extends TestCase
         $this->assertInstanceOf(HttpHandler::class, $handler);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "This is not a valid HTTP header\r\n\r\n";
+            return "This is not a valid HTTP header\r\n";
         });
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Invalid Http request.");

--- a/tests/suites/middleware/CallbackTest.php
+++ b/tests/suites/middleware/CallbackTest.php
@@ -120,7 +120,13 @@ class CallbackTest extends TestCase
             return $message;
         }));
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET /a/path?a=b HTTP/1.1\r\nHost: test.com:123\r\n\r\n";
+            return "GET /a/path?a=b HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: test.com:123\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $message = $connection->pullHttp();
         $this->assertEquals('POST', $message->getMethod());

--- a/tests/suites/middleware/FollowRedirectTest.php
+++ b/tests/suites/middleware/FollowRedirectTest.php
@@ -72,7 +72,13 @@ class FollowRedirectTest extends TestCase
         $connection->addMiddleware($middleware);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 301 Moved Permanently\r\nLocation: ws://redirect.to/new/target\r\n\r\n";
+            return "HTTP/1.1 301 Moved Permanently\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Location: ws://redirect.to/new/target\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamClose();
@@ -97,7 +103,13 @@ class FollowRedirectTest extends TestCase
         $connection->addMiddleware($middleware);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 301 Moved Permanently\r\nLocation: ws://redirect.to/new/target\r\n\r\n";
+            return "HTTP/1.1 301 Moved Permanently\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Location: ws://redirect.to/new/target\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamClose();
@@ -122,7 +134,10 @@ class FollowRedirectTest extends TestCase
         $connection->addMiddleware($middleware);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 301 Moved Permanently\r\n\r\n";
+            return "HTTP/1.1 301 Moved Permanently\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $response = $connection->pullHttp();
         $this->expectSocketStreamIsConnected();

--- a/tests/suites/middleware/SubprotocolNegotiationTest.php
+++ b/tests/suites/middleware/SubprotocolNegotiationTest.php
@@ -73,7 +73,13 @@ class SubprotocolNegotiationTest extends TestCase
         $this->assertNull($connection->getMeta('subprotocolNegotiation.selected'));
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 200 OK\r\nSec-WebSocket-Protocol: sp-2\r\n\r\n";
+            return "HTTP/1.1 200 OK\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-2\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $response = $connection->pullHttp();
         $this->assertEquals(['sp-2'], $response->getHeader('Sec-WebSocket-Protocol'));
@@ -118,7 +124,10 @@ class SubprotocolNegotiationTest extends TestCase
         $this->assertNull($connection->getMeta('subprotocolNegotiation.selected'));
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 200 OK\r\n\r\n";
+            return "HTTP/1.1 200 OK\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $response = $connection->pullHttp();
         $this->assertEquals([], $response->getHeader('Sec-WebSocket-Protocol'));
@@ -163,7 +172,10 @@ class SubprotocolNegotiationTest extends TestCase
         $this->assertNull($connection->getMeta('subprotocolNegotiation.selected'));
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "HTTP/1.1 200 OK\r\n\r\n";
+            return "HTTP/1.1 200 OK\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamWrite();
         $this->expectSocketStreamIsConnected();
@@ -191,10 +203,22 @@ class SubprotocolNegotiationTest extends TestCase
         $connection->addMiddleware($middleware);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET / HTTP/1.1\r\nHost: test.url\r\n"
-                . "Sec-WebSocket-Protocol: sp-11\r\n"
-                . "Sec-WebSocket-Protocol: sp-2\r\n"
-                . "Sec-WebSocket-Protocol: sp-33\r\n\r\n";
+            return "GET / HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: test.url\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-11\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-2\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-33\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $request = $connection->pullHttp();
         $this->assertEquals(['sp-11', 'sp-2', 'sp-33'], $request->getHeader('Sec-WebSocket-Protocol'));
@@ -236,11 +260,24 @@ class SubprotocolNegotiationTest extends TestCase
         $connection->addMiddleware($middleware);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET / HTTP/1.1\r\nHost: test.url\r\n"
-                . "Sec-WebSocket-Protocol: sp-11\r\n"
-                . "Sec-WebSocket-Protocol: sp-22\r\n"
-                . "Sec-WebSocket-Protocol: sp-33\r\n\r\n";
+            return "GET / HTTP/1.1\r\n";
         });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: test.url\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-11\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-22\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-33\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
+        });
+
         $request = $connection->pullHttp();
         $this->assertEquals(['sp-11', 'sp-22', 'sp-33'], $request->getHeader('Sec-WebSocket-Protocol'));
         $this->assertNull($connection->getMeta('subprotocolNegotiation.selected'));
@@ -281,11 +318,24 @@ class SubprotocolNegotiationTest extends TestCase
         $connection->addMiddleware($middleware);
 
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET / HTTP/1.1\r\nHost: test.url\r\n"
-                . "Sec-WebSocket-Protocol: sp-11\r\n"
-                . "Sec-WebSocket-Protocol: sp-22\r\n"
-                . "Sec-WebSocket-Protocol: sp-33\r\n\r\n";
+            return "GET / HTTP/1.1\r\n";
         });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: test.url\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-11\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-22\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Protocol: sp-33\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
+        });
+
         $request = $connection->pullHttp();
         $this->assertEquals(['sp-11', 'sp-22', 'sp-33'], $request->getHeader('Sec-WebSocket-Protocol'));
         $this->assertNull($connection->getMeta('subprotocolNegotiation.selected'));

--- a/tests/suites/server/HandshakeTest.php
+++ b/tests/suites/server/HandshakeTest.php
@@ -133,9 +133,25 @@ class HandshakeTest extends TestCase
             $server->stop();
         });
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "POST / HTTP/1.1\r\nHost: localhost\r\n"
-            . "Connection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n"
-            . "Sec-WebSocket-Version: 13\r\n\r\n";
+            return "POST / HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: localhost\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Connection: Upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Upgrade: websocket\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Version: 13\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 405 Method Not Allowed\r\n\r\n", $params[0]);
@@ -167,9 +183,25 @@ class HandshakeTest extends TestCase
             $server->stop();
         });
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET / HTTP/1.1\r\nHost: localhost\r\n"
-            . "Connection: Invalid\r\nUpgrade: websocket\r\nSec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n"
-            . "Sec-WebSocket-Version: 13\r\n\r\n";
+            return "GET / HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: localhost\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Connection: Invalid\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Upgrade: websocket\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Version: 13\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\n\r\n", $params[0]);
@@ -201,9 +233,25 @@ class HandshakeTest extends TestCase
             $server->stop();
         });
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET / HTTP/1.1\r\nHost: localhost\r\n"
-            . "Connection: Upgrade\r\nUpgrade: Invalid\r\nSec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n"
-            . "Sec-WebSocket-Version: 13\r\n\r\n";
+            return "GET / HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: localhost\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Connection: Upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Upgrade: Invalid\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Version: 13\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\n\r\n", $params[0]);
@@ -235,9 +283,25 @@ class HandshakeTest extends TestCase
             $server->stop();
         });
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET / HTTP/1.1\r\nHost: localhost\r\n"
-            . "Connection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n"
-            . "Sec-WebSocket-Version: 12\r\n\r\n";
+            return "GET / HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: localhost\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Connection: Upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Upgrade: websocket\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Version: 12\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\nSec-WebSocket-Version: 13\r\n\r\n", $params[0]);
@@ -269,9 +333,22 @@ class HandshakeTest extends TestCase
             $server->stop();
         });
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET / HTTP/1.1\r\nHost: localhost\r\n"
-            . "Connection: Upgrade\r\nUpgrade: websocket\r\n"
-            . "Sec-WebSocket-Version: 13\r\n\r\n";
+            return "GET / HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: localhost\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Connection: Upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Upgrade: websocket\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Version: 13\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\n\r\n", $params[0]);
@@ -303,9 +380,25 @@ class HandshakeTest extends TestCase
             $server->stop();
         });
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET / HTTP/1.1\r\nHost: localhost\r\n"
-            . "Connection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: jww=\r\n"
-            . "Sec-WebSocket-Version: 13\r\n\r\n";
+            return "GET / HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: localhost\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Connection: Upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Upgrade: websocket\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Key: jww=\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Version: 13\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\n\r\n", $params[0]);
@@ -337,9 +430,25 @@ class HandshakeTest extends TestCase
             $server->stop();
         });
         $this->expectSocketStreamReadLine()->setReturn(function () {
-            return "GET / HTTP/1.1\r\nHost: localhost\r\n"
-            . "Connection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n"
-            . "Sec-WebSocket-Version: 13\r\n\r\n";
+            return "GET / HTTP/1.1\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Host: localhost\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Connection: Upgrade\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Upgrade: websocket\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Key: cktLWXhUdDQ2OXF0ZCFqOQ==\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "Sec-WebSocket-Version: 13\r\n";
+        });
+        $this->expectSocketStreamReadLine()->setReturn(function () {
+            return "\r\n";
         });
         $this->expectSocketStreamWrite()->setReturn(function () {
             throw new StreamException(StreamException::FAIL_WRITE);


### PR DESCRIPTION
- Check incoming HTTP request earlier. If invalid, exit directly without trying to read more.
- Break if stream do not have expected data.

Closes #83 