### PR TITLE
Fix connection error when the reason is empty

### DIFF
--- a/src/Http/HttpHandler.php
+++ b/src/Http/HttpHandler.php
@@ -59,7 +59,7 @@ class HttpHandler implements LoggerAwareInterface, Stringable
         }
 
         // Pulling response
-        preg_match('!^HTTP/(?P<version>[0-9/.]+) (?P<code>[0-9]*) (?P<reason>.*)!', $status, $matches);
+        preg_match('!^HTTP\/(?P<version>[0-9\/.]+) (?P<code>[0-9]*)(?P<reason>.*)!', $status, $matches);
         if (!empty($matches)) {
             $message = new Response((int)$matches['code'], $matches['reason']);
             $version = $matches['version'];

--- a/src/Http/HttpHandler.php
+++ b/src/Http/HttpHandler.php
@@ -59,7 +59,7 @@ class HttpHandler implements LoggerAwareInterface, Stringable
         }
 
         // Pulling response
-        preg_match('!^HTTP\/(?P<version>[0-9\/.]+) (?P<code>[0-9]*)(?P<reason>.*)!', $status, $matches);
+        preg_match('!^HTTP/(?P<version>[0-9/.]+) (?P<code>[0-9]*)($|\s(?P<reason>.*))!', $status, $matches);
         if (!empty($matches)) {
             $message = new Response((int)$matches['code'], $matches['reason']);
             $version = $matches['version'];

--- a/src/Http/HttpHandler.php
+++ b/src/Http/HttpHandler.php
@@ -61,7 +61,7 @@ class HttpHandler implements LoggerAwareInterface, Stringable
         // Pulling response
         preg_match('!^HTTP/(?P<version>[0-9/.]+) (?P<code>[0-9]*)($|\s(?P<reason>.*))!', $status, $matches);
         if (!empty($matches)) {
-            $message = new Response((int)$matches['code'], $matches['reason']);
+            $message = new Response((int)$matches['code'], $matches['reason'] ?? '');
             $version = $matches['version'];
         }
 

--- a/tests/suites/client/HandshakeTest.php
+++ b/tests/suites/client/HandshakeTest.php
@@ -72,7 +72,7 @@ class HandshakeTest extends TestCase
         $response = $client->getHandshakeResponse();
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(101, $response->getStatusCode());
-        $this->assertEquals('Switching Protocols', $response->getReasonPhrase());
+        $this>assertContains($response->getReasonPhrase(), ['Switching Protocols', '', ' ']);
 
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamClose();
@@ -200,7 +200,7 @@ class HandshakeTest extends TestCase
         $response = $client->getHandshakeResponse();
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(101, $response->getStatusCode());
-        $this->assertEquals('Switching Protocols', $response->getReasonPhrase());
+        $this>assertContains($response->getReasonPhrase(), ['Switching Protocols', '', ' ']);
 
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamClose();

--- a/tests/suites/client/HandshakeTest.php
+++ b/tests/suites/client/HandshakeTest.php
@@ -72,7 +72,7 @@ class HandshakeTest extends TestCase
         $response = $client->getHandshakeResponse();
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(101, $response->getStatusCode());
-        $this>assertContains($response->getReasonPhrase(), ['Switching Protocols', '', ' ']);
+        $this->assertEquals('Switching Protocols', $response->getReasonPhrase());
 
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamClose();
@@ -200,7 +200,7 @@ class HandshakeTest extends TestCase
         $response = $client->getHandshakeResponse();
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(101, $response->getStatusCode());
-        $this>assertContains($response->getReasonPhrase(), ['Switching Protocols', '', ' ']);
+        $this->assertEquals('Switching Protocols', $response->getReasonPhrase());
 
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamClose();


### PR DESCRIPTION
It seems not every websocket server is responding with a reason, for example `wss://nostr.wine`
I found it while I was debugging some WebSocket connections, see https://github.com/nostrver-se/nostr-php/pull/82#issuecomment-2639845035 and I also reached out to the server operator: https://njump.me/nevent1qvzqqqqqqypzq0vy9tlv6h3f8u5tvcnexdcy50acec2n42ga0y9tz8m2w5k5ffpdqyv8wumn8ghj7enfd36x2u3wdehhxarj9emkjmn99uq3samnwvaz7tmrv4kxcctj9ehx7um5wgh8w6twv5hsqgrlme92sxxstf3dvha5a78mnrz9ea7eguaaw2lrvjxtu460y9fz0ykfrp9c 

With this change the regex is less strict allowing an empty reason. 