### PR TITLE
#103 onerror type issue

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,11 @@
 
  > PHP version `^8.1`
 
+### `3.2.4`
+
+ * Introducing ExceptionInterface as root to internal exceptions (@sirn-se)
+ * Unresolvable errors must not trigger onError listener (@sirn-se)
+
 ### `3.2.3`
 
  * Allow empty reason phrase in HTTP request (@Sebastix)

--- a/docs/Class_Synopsis.md
+++ b/docs/Class_Synopsis.md
@@ -238,7 +238,7 @@ class WebSocket\Exception\ConnectionFailureException extends WebSocket\Exception
 ### ConnectionLevelInterface
 
 ```php
-interface WebSocket\Exception\ConnectionLevelInterface
+interface WebSocket\Exception\ConnectionLevelInterface extends WebSocket\Exception\ExceptionInterface
 {
 }
 ```
@@ -255,7 +255,15 @@ class WebSocket\Exception\ConnectionTimeoutException extends WebSocket\Exception
 ### Exception
 
 ```php
-abstract class WebSocket\Exception\Exception extends RuntimeException
+abstract class WebSocket\Exception\Exception extends RuntimeException implements WebSocket\Exception\ExceptionInterface
+{
+}
+```
+
+### ExceptionInterface
+
+```php
+interface WebSocket\Exception\ExceptionInterface
 {
 }
 ```
@@ -273,7 +281,7 @@ class WebSocket\Exception\HandshakeException extends WebSocket\Exception\Excepti
 ### MessageLevelInterface
 
 ```php
-interface WebSocket\Exception\MessageLevelInterface
+interface WebSocket\Exception\MessageLevelInterface extends WebSocket\Exception\ExceptionInterface
 {
 }
 ```

--- a/docs/Listener.md
+++ b/docs/Listener.md
@@ -64,7 +64,7 @@ Connection might be null. The Exception thrown is present as last argument.
 ```php
 $client_or_server
     // When a resolvable error occurs, this listener will be called
-    ->onError(function (WebSocket\Client|WebSocket\Server $client_or_server, WebSocket\Connection|null $connection, WebSocket\Exception\Exception $exception) {
+    ->onError(function (WebSocket\Client|WebSocket\Server $client_or_server, WebSocket\Connection|null $connection, WebSocket\Exception\ExceptionInterface $exception) {
         // Act on exception
     })
     ;
@@ -76,6 +76,9 @@ Using above functions, your Client and Server will be able to receive incoming m
 
 But what if your implementation need to process other data, and send unsolicited messages?
 The coroutine implementation will regularly call the `onTick()` method, depending on workload and configuration.
+
+It will be called at the end of each coroutine loop.
+In other words, when all incoming messages has been read *or* timeout has been reached.
 
 ```php
 $client_or_server

--- a/src/Client.php
+++ b/src/Client.php
@@ -316,7 +316,6 @@ class Client implements LoggerAwareInterface, Stringable
 
                 // Crash it
                 $this->logger->error("[client] {$e->getMessage()}");
-                $this->dispatch('error', [$this, null, $e]);
                 throw $e;
             }
             gc_collect_cycles(); // Collect garbage

--- a/src/Client.php
+++ b/src/Client.php
@@ -29,7 +29,7 @@ use WebSocket\Exception\{
     BadUriException,
     ClientException,
     ConnectionLevelInterface,
-    Exception,
+    ExceptionInterface,
     HandshakeException,
     MessageLevelInterface,
     ReconnectException
@@ -303,7 +303,7 @@ class Client implements LoggerAwareInterface, Stringable
                 }
                 $this->connection->tick();
                 $this->dispatch('tick', [$this]);
-            } catch (Exception $e) {
+            } catch (ExceptionInterface $e) {
                 $this->disconnect();
                 $this->running = false;
 

--- a/src/Exception/ConnectionLevelInterface.php
+++ b/src/Exception/ConnectionLevelInterface.php
@@ -11,6 +11,6 @@ namespace WebSocket\Exception;
  * WebSocket\Exception\ConnectionLevelInterface interface.
  * Indicates error on connection level - connection should be closed
  */
-interface ConnectionLevelInterface
+interface ConnectionLevelInterface extends ExceptionInterface
 {
 }

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -13,6 +13,6 @@ use RuntimeException;
  * WebSocket\Exception\Exception abstract class.
  * Core exception for repo
  */
-abstract class Exception extends RuntimeException
+abstract class Exception extends RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -8,9 +8,9 @@
 namespace WebSocket\Exception;
 
 /**
- * WebSocket\Exception\MessageLevelInterface interface.
- * Indicates issue reading/writing message.
+ * WebSocket\Exception\ExceptionInterface interface.
+ * Root interface for internal exceptions.
  */
-interface MessageLevelInterface extends ExceptionInterface
+interface ExceptionInterface
 {
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -26,7 +26,7 @@ use WebSocket\Exception\{
     CloseException,
     ConnectionFailureException,
     ConnectionLevelInterface,
-    Exception,
+    ExceptionInterface,
     HandshakeException,
     MessageLevelInterface,
     ServerException
@@ -381,7 +381,7 @@ class Server implements LoggerAwareInterface, Stringable
                     $connection->tick();
                 }
                 $this->dispatch('tick', [$this]);
-            } catch (Exception $e) {
+            } catch (ExceptionInterface $e) {
                 // Low-level error
                 $this->logger->error("[server] {$e->getMessage()}");
                 $this->dispatch('error', [$this, null, $e]);
@@ -515,7 +515,7 @@ class Server implements LoggerAwareInterface, Stringable
                 $connection->getHandshakeResponse(),
             ]);
             $this->dispatch('connect', [$this, $connection, $request]);
-        } catch (Exception | StreamException $e) {
+        } catch (ExceptionInterface | StreamException $e) {
             /** @var Connection|null $connection */
             if (isset($connection)) {
                 $connection->disconnect();

--- a/src/Server.php
+++ b/src/Server.php
@@ -388,7 +388,6 @@ class Server implements LoggerAwareInterface, Stringable
             } catch (Throwable $e) {
                 // Crash it
                 $this->logger->error("[server] {$e->getMessage()}");
-                $this->dispatch('error', [$this, null, $e]);
                 $this->disconnect();
                 throw $e;
             }

--- a/src/Trait/ListenerTrait.php
+++ b/src/Trait/ListenerTrait.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\{
 };
 use Throwable;
 use WebSocket\Connection;
+use WebSocket\Exception\ExceptionInterface;
 use WebSocket\Message\Message;
 
 /**
@@ -85,7 +86,7 @@ trait ListenerTrait
         return $this;
     }
 
-    /** @param Closure(T, Connection|null, Throwable): void $closure */
+    /** @param Closure(T, Connection|null, ExceptionInterface): void $closure */
     public function onError(Closure $closure): self
     {
         $this->listeners['error'] = $closure;
@@ -103,7 +104,7 @@ trait ListenerTrait
      * @param array{
      *   0: T,
      *   1?: Connection|null,
-     *   2?: Message|RequestInterface|ResponseInterface|Throwable|null,
+     *   2?: Message|RequestInterface|ResponseInterface|ExceptionInterface|null,
      *   3?: ResponseInterface|null
      * } $args
      */

--- a/tests/suites/client/ClientTest.php
+++ b/tests/suites/client/ClientTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WebSocket\Test\Client;
 
+use Error;
 use PHPUnit\Framework\TestCase;
 use Phrity\Net\Mock\StreamCollection;
 use Phrity\Net\Mock\StreamFactory;
@@ -1062,6 +1063,32 @@ class ClientTest extends TestCase
         $this->expectExceptionMessage('Stream is detached.');
         $client->start();
 
+        unset($client);
+    }
+
+    public function testUnresolvableError(): void
+    {
+        $this->expectStreamFactory();
+        $client = new Client('ws://localhost:8000/my/mock/path');
+        $client->setStreamFactory(new StreamFactory());
+
+        $client->onTick(function ($client) {
+            // Trigger unresolvable error
+            $fail = new UnexistingClass();
+        });
+
+        $this->expectWsClientConnect();
+        $this->expectWsClientPerformHandshake();
+        $this->expectWsSelectConnections(['localhost:8000']);
+        $this->expectSocketStreamRead()->setReturn(function () {
+            return base64_decode('gQA=');
+        });
+        $this->expectSocketStreamIsConnected();
+        $this->expectSocketStreamIsConnected();
+        $this->expectSocketStreamClose();
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Class "WebSocket\Test\Client\UnexistingClass" not found');
+        $client->start();
         unset($client);
     }
 }

--- a/tests/suites/server/ServerTest.php
+++ b/tests/suites/server/ServerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WebSocket\Test\Server;
 
+use Error;
 use PHPUnit\Framework\TestCase;
 use Phrity\Net\Mock\StreamCollection;
 use Phrity\Net\Mock\StreamFactory;
@@ -826,6 +827,42 @@ class ServerTest extends TestCase
 
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamClose();
+        unset($server);
+    }
+
+    public function testUnresolvableError(): void
+    {
+        $this->expectStreamFactory();
+        $server = new Server(8000);
+        $server->setStreamFactory(new StreamFactory());
+
+        $server->onTick(function ($server) {
+            // Trigger unresolvable error
+            $fail = new UnexistingClass();
+        });
+
+        $this->expectWsServerSetup(scheme: 'tcp', port: 8000);
+        $this->expectWsSelectConnections(['@server']);
+        // Accept connection
+        $this->expectSocketServerAccept();
+        $this->expectSocketStream();
+        $this->expectSocketStreamGetMetadata();
+        $this->expectSocketStreamGetRemoteName()->setReturn(function () {
+            return 'fake-connection-1';
+        });
+        $this->expectStreamCollectionAttach();
+        $this->expectSocketStreamGetLocalName()->setReturn(function () {
+            return 'fake-connection-1';
+        });
+        $this->expectSocketStreamGetRemoteName();
+        $this->expectSocketStreamSetTimeout();
+        $this->expectWsServerPerformHandshake();
+        $this->expectSocketStreamClose();
+        $this->expectSocketServerClose();
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Class "WebSocket\Test\Server\UnexistingClass" not found');
+        $server->start();
+
         unset($server);
     }
 }


### PR DESCRIPTION
Unresolvable errors must **not** be used in `onError` listener callback.

- Introducing `ExceptionInterface` as root interface for all internal exceptions
- Removing calls to `dispatch()` on errors not implementing `ExceptionInterface`

Closing #103 