### PR TITLE
Allow additional content in Connection header during handshake

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -93,6 +93,10 @@
 
  > PHP version `^8.0`
 
+### `2.1.3`
+
+ * Allow additional content in Connection header during handshake (@sirn-se)
+
 ### `2.1.2`
 
  * Allow repeated headers when pulling HTTP messages (@sirn-se)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,10 @@
 
  > PHP version `^8.1`
 
+### `3.2.5`
+
+ * Allow additional content in Connection header during handshake - again (@sirn-se)
+
 ### `3.2.4`
 
  * Introducing ExceptionInterface as root to internal exceptions (@sirn-se)

--- a/src/Http/Message.php
+++ b/src/Http/Message.php
@@ -26,7 +26,7 @@ abstract class Message implements MessageInterface, Stringable
 
     protected string $version = '1.1';
     /** @var array<string, array<mixed>> $headers */
-    protected array $headers = [];
+    private array $headers = [];
 
     /**
      * Retrieves the HTTP protocol version as a string.
@@ -100,9 +100,7 @@ abstract class Message implements MessageInterface, Stringable
     public function withHeader(string $name, mixed $value): self
     {
         $new = clone $this;
-        if ($this->hasHeader($name)) {
-            unset($new->headers[strtolower($name)]);
-        }
+        $new->removeHeader($name);
         $new->handleHeader($name, $value);
         return $new;
     }
@@ -130,9 +128,7 @@ abstract class Message implements MessageInterface, Stringable
     public function withoutHeader(string $name): self
     {
         $new = clone $this;
-        if ($this->hasHeader($name)) {
-            unset($new->headers[strtolower($name)]);
-        }
+        $new->removeHeader($name);
         return $new;
     }
 
@@ -164,7 +160,7 @@ abstract class Message implements MessageInterface, Stringable
         return $lines;
     }
 
-    private function handleHeader(string $name, mixed $value): void
+    protected function handleHeader(string $name, mixed $value): void
     {
         if (!preg_match('|^[0-9a-zA-Z#_-]+$|', $name)) {
             throw new InvalidArgumentException("'{$name}' is not a valid header field name.");
@@ -176,6 +172,13 @@ abstract class Message implements MessageInterface, Stringable
             }
             $content = trim($content);
             $this->headers[strtolower($name)][$name][] = $content;
+        }
+    }
+
+    protected function removeHeader(string $name): void
+    {
+        if ($this->hasHeader($name)) {
+            unset($this->headers[strtolower($name)]);
         }
     }
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -35,7 +35,7 @@ class Request extends Message implements RequestInterface
         }
         $this->uri = $uri instanceof Uri ? $uri : new Uri((string)$uri);
         $this->method = $method;
-        $this->headers = ['host' => ['Host' => [$this->formatHostHeader($this->uri)]]];
+        $this->handleHeader('Host', $this->formatHostHeader($this->uri));
     }
 
     /**
@@ -109,10 +109,8 @@ class Request extends Message implements RequestInterface
         $new = clone $this;
         $new->uri = $uri instanceof Uri ? $uri : new Uri((string)$uri);
         if (!$preserveHost || !$new->hasHeader('host')) {
-            if (isset($new->headers['host'])) {
-                unset($new->headers['host']);
-            }
-            $new->headers = array_merge(['host' => ['Host' => [$this->formatHostHeader($uri)]]], $new->headers);
+            $new->removeHeader('host');
+            $new->handleHeader('Host', $this->formatHostHeader($uri));
         }
         return $new;
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -556,7 +556,7 @@ class Server implements LoggerAwareInterface, Stringable
                 );
             }
             $connectionHeader = trim($request->getHeaderLine('Connection'));
-            if (strtolower($connectionHeader) != 'upgrade') {
+            if (!str_contains('upgrade', strtolower($connectionHeader))) {
                 throw new HandshakeException(
                     "Handshake request with invalid Connection header: '{$connectionHeader}'",
                     $response->withStatus(426)


### PR DESCRIPTION
Fixed in `2.1.3` but got lost along the way.

Closes #107 