### PR TITLE
reverse args in str_contains

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -556,7 +556,7 @@ class Server implements LoggerAwareInterface, Stringable
                 );
             }
             $connectionHeader = trim($request->getHeaderLine('Connection'));
-            if (!str_contains('upgrade', strtolower($connectionHeader))) {
+            if (!str_contains(strtolower($connectionHeader), 'upgrade')) {
                 throw new HandshakeException(
                     "Handshake request with invalid Connection header: '{$connectionHeader}'",
                     $response->withStatus(426)


### PR DESCRIPTION
Looks like the last release still didn't address the issue, due to this reverse arg list.