### PR TITLE
Add non-blocking hasMessage() method to bypass stream_set_timeout() limitations

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -507,6 +507,15 @@ class Client implements LoggerAwareInterface, Stringable
         return $this->connection ? $this->connection->getHandshakeResponse() : null;
     }
 
+    /**
+     * Check if there are messages available to read without blocking.
+     * @return bool True if there are messages available to read, false otherwise.
+     */
+    public function hasMessages(): bool
+    {
+        return $this->connection ? $this->connection->hasMessages() : false;
+    }
+
 
     /* ---------- Internal helper methods -------------------------------------------------------------------------- */
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -247,6 +247,28 @@ class Connection implements LoggerAwareInterface, Stringable
         return $this;
     }
 
+    /**
+     * Check if there are messages available to read without blocking.
+     * @return bool True if there are messages available to read, false otherwise.
+     */
+    public function hasMessages(): bool
+    {
+        if (!$this->isConnected()) {
+            return false;
+        }
+
+        $resource = $this->stream->getResource();
+        if (!$resource) {
+            return false;
+        }
+
+        $read = [$resource];
+        $write = null;
+        $except = null;
+        
+        return @stream_select($read, $write, $except, 0, 0) > 0;
+    }
+
 
     /* ---------- Connection state --------------------------------------------------------------------------------- */
 


### PR DESCRIPTION
This patch introduces a non-blocking `hasMessage()` method to enable sub-second polling of socket streams, addressing a core limitation in PHP's native timeout behavior.

---

### Problem

PHP’s `stream_set_timeout()` is unreliable for real-time or low-latency applications:

- **Sub-second timeouts** — for example:

    `stream_set_timeout($stream, 0, 100000); // 100ms`

  appear to accept microsecond precision, but in practice:

  - The stream blocks for a full second or longer.
  - This is because many PHP builds (and the underlying OS socket layers) round up or ignore the microsecond portion.
  - For example:
    - On **Linux**, the timeout is commonly treated as 1 second 
    - On **macOS**, behavior varies by stream type and microsecond values are often ignored entirely
    - On **Windows**, behavior is inconsistent


### Testing 

on Linux shows that even extreme cases like:

 `stream_set_timeout($stream, 0, 1); // 1 microsecond`

do not produce a short timeout. Instead, this causes the stream to **block indefinitely, because a 0-second timeout disables the timeout mechanism.** 

This is functionally equivalent to:

`stream_set_timeout($stream, 0);`

which causes the stream to block forever until data arrives.


---

### Solution

The  `hasMessage()` method uses `stream_select()` internally to:

- Check for incoming data without blocking  
- Avoid reliance on unreliable microsecond timeouts  
- Enable tight-loop polling or integration into event loops with minimal latency  

---

### Benefits

- Consistent, cross-platform behavior  
- Preserves compatibility with existing code  
- Improves real-time responsiveness in PHP-based socket applications  

---

### Use Cases

- Tight application loops (e.g. game loops, schedulers, real-time monitoring) that cannot afford to block for up to 1 second  
- Non-critical incoming messages where the application may choose to skip processing 
- Asymmetric communication patterns, such as:  
  - Outgoing messages are time-sensitive 
  - Incoming messages are optional, non-urgent, or can be discarded if not immediately present  

