### PR TITLE
Stream v2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.1",
         "phrity/net-uri": "^2.1",
-        "phrity/net-stream": "dev-2.3-updates as 2.2.1",
+        "phrity/net-stream": "^2.3",
         "psr/http-message": "^1.1 | ^2.0",
         "psr/log": "^1.0 | ^2.0 | ^3.0"
     },
@@ -36,7 +36,7 @@
         "php-coveralls/php-coveralls": "^2.0",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^10.0 | ^11.0 | ^12.0",
-        "phrity/net-mock": "dev-2.3-updates as 2.2.1",
+        "phrity/net-mock": "^2.3",
         "phrity/util-errorhandler": "^1.1",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -40,13 +40,6 @@
         "phrity/util-errorhandler": "^1.1",
         "squizlabs/php_codesniffer": "^3.5"
     },
-    "repositories": [
-        {
-          "type": "path",
-          "url": "../phrity-net-stream",
-          "canonical": false
-        }
-      ],
     "suggests": {
         "ext-zlib": "Required for per-message deflate compression"
     }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.1",
         "phrity/net-uri": "^2.1",
-        "phrity/net-stream": "^2.2",
+        "phrity/net-stream": "dev-2.3-updates as 2.2.1",
         "psr/http-message": "^1.1 | ^2.0",
         "psr/log": "^1.0 | ^2.0 | ^3.0"
     },
@@ -36,10 +36,17 @@
         "php-coveralls/php-coveralls": "^2.0",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^10.0 | ^11.0 | ^12.0",
-        "phrity/net-mock": "^2.2",
+        "phrity/net-mock": "dev-2.3-updates as 2.2.1",
         "phrity/util-errorhandler": "^1.1",
         "squizlabs/php_codesniffer": "^3.5"
     },
+    "repositories": [
+        {
+          "type": "path",
+          "url": "../phrity-net-stream",
+          "canonical": false
+        }
+      ],
     "suggests": {
         "ext-zlib": "Required for per-message deflate compression"
     }

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8,6 +8,8 @@
 
 ### `3.5.0`
 
+ * Timeouts support float (@sirn-se)
+ * Client and Server start() can have specific timeout (@sirn-se)
  * Internal LoggerAwareTrait for logger handling (@sirn-se)
  * Constant in interface (@sirn-se)
  * Frame pulling rewritten (@sirn-se)

--- a/docs/Class_Synopsis.md
+++ b/docs/Class_Synopsis.md
@@ -18,8 +18,8 @@ class WebSocket\Client implements Psr\Log\LoggerAwareInterface, Stringable
     // Configuration
     public function setStreamFactory(Phrity\Net\StreamFactory $streamFactory): self;
     public function setLogger(Psr\Log\LoggerInterface $logger): void;
-    public function setTimeout(int $timeout): self;
-    public function getTimeout(): int;
+    public function setTimeout(int|float $timeout): self;
+    public function getTimeout(): int|float;
     public function setFrameSize(int $frameSize): self;
     public function getFrameSize(): int;
     public function setPersistent(bool $persistent): self;
@@ -38,7 +38,7 @@ class WebSocket\Client implements Psr\Log\LoggerAwareInterface, Stringable
     public function close(int $status = 1000, string $message = 'ttfn'): WebSocket\Message\Close;
 
     // Listener operations
-    public function start(): void;
+    public function start(int|float|null $timeout = null): void;
     public function stop(): void;
     public function isRunning(): bool;
 
@@ -81,8 +81,8 @@ class WebSocket\Server implements Psr\Log\LoggerAwareInterface, Stringable
     // Configuration
     public function setStreamFactory(Phrity\Net\StreamFactory $streamFactory): self;
     public function setLogger(Psr\Log\LoggerInterface $logger): void;
-    public function setTimeout(int $timeout): self;
-    public function getTimeout(): int;
+    public function setTimeout(int|float $timeout): self;
+    public function getTimeout(): int|float;
     public function setFrameSize(int $frameSize): self;
     public function getFrameSize(): int;
     public function getPort(): int;
@@ -106,7 +106,7 @@ class WebSocket\Server implements Psr\Log\LoggerAwareInterface, Stringable
     public function close(int $status = 1000, string $message = 'ttfn'): WebSocket\Message\Close;
 
     // Listener operations
-    public function start(): void;
+    public function start(int|float|null $timeout = null): void;
     public function stop(): void;
     public function isRunning(): bool;
 
@@ -140,8 +140,8 @@ class WebSocket\Connection implements Psr\Log\LoggerAwareInterface, Stringable
 
     // Configuration
     public function setLogger(Psr\Log\LoggerInterface $logger): void;
-    public function setTimeout(int $timeout): self;
-    public function getTimeout(): int;
+    public function setTimeout(int|float $timeout): self;
+    public function getTimeout(): int|float;
     public function setFrameSize(int $frameSize): self;
     public function getFrameSize(): int;
     public function getContext(): Phrity\Net\Context;

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -46,6 +46,7 @@ $client
     })
     ->start();
 ```
+Optionally, `start()` can take timeout argument as int or float.
 
 ## Middlewares
 
@@ -150,7 +151,7 @@ $client->setLogger(Psr\Log\LoggerInterface $logger);
 
 Timeout for various operations can be specified in seconds.
 This affects how long Client will wait for connection, read and write operations, and listener scope.
-Default is `60` seconds. Minimum is `0` seconds.
+Default is `60` seconds. Minimum is `0` seconds. Accepts int or float value.
 Avoid setting very low values as it will cause a read loop to use all
 available processing power even when there's nothing to read.
 

--- a/docs/Connection.md
+++ b/docs/Connection.md
@@ -94,7 +94,7 @@ $connection->setLogger(Psr\Log\LoggerInterface $logger);
 
 Timeout for various operations can be specified in seconds.
 This affects how long a Connection will wait for read and write operations.
-Default is `60` seconds. Minimum is `0` seconds.
+Default is `60` seconds. Minimum is `0` seconds.  Accepts int or float value.
 Avoid setting very low values as it will cause a read loop to use all
 available processing power even when there's nothing to read.
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -25,6 +25,8 @@ $server
     })
     ->start();
 ```
+Optionally, `start()` can take timeout argument as int or float.
+
 
 ## Middlewares
 
@@ -150,7 +152,7 @@ $server->setLogger(Psr\Log\LoggerInterface $logger);
 
 Timeout for various operations can be specified in seconds.
 This affects how long Server will wait for connection, read and write operations, and listener scope.
-Default is `60` seconds. Minimum is `0` seconds.
+Default is `60` seconds. Minimum is `0` seconds.  Accepts int or float value.
 Avoid setting very low values as it will cause a read loop to use all
 available processing power even when there's nothing to read.
 

--- a/examples/delegating_server.php
+++ b/examples/delegating_server.php
@@ -13,7 +13,7 @@
  *  --remote <string> : Upstream server to delegate, required
  *  --port <int> : The port to listen to, default 80
  *  --ssl : Use SSL, default false
- *  --timeout <int> : Timeout in seconds
+ *  --timeout <int|float> : Timeout in seconds
  *  --framesize <int> : Frame payload size in bytes
  *  --connections <int> : Max number of connections, default unlimited
  *  --deflate : Add support for per-message deflate compression
@@ -49,7 +49,7 @@ echo "# Delegating server! [phrity/websocket]\n";
  *     remote: string,
  *     port: int<1, 32768>,
  *     ssl: bool,
- *     timeout: int<0, max>,
+ *     timeout: int<0, max>|float,
  *     framesize: int<1, max>,
  *     connections: int<0, max>|null,
  *     deflate: bool,

--- a/examples/echoserver.php
+++ b/examples/echoserver.php
@@ -11,7 +11,7 @@
  * Console options:
  *  --port <int> : The port to listen to, default 80
  *  --ssl : Use SSL, default false
- *  --timeout <int> : Timeout in seconds
+ *  --timeout <int|float> : Timeout in seconds
  *  --framesize <int> : Frame payload size in bytes
  *  --connections <int> : Max number of connections, default unlimited
  *  --deflate : Add support for per-message deflate compression
@@ -48,7 +48,7 @@ echo "# Echo server! [phrity/websocket]\n";
  * @var array{
  *     port: int<1, 32768>,
  *     ssl: bool,
- *     timeout: int<0, max>,
+ *     timeout: int<0, max>|float,
  *     framesize: int<1, max>,
  *     connections: int<0, max>|null,
  *     deflate: bool,

--- a/examples/random_client.php
+++ b/examples/random_client.php
@@ -11,7 +11,7 @@
  *
  * Console options:
  *  --uri <uri> : The URI to connect to, default ws://localhost:8000
- *  --timeout <int> : Timeout in seconds, random default
+ *  --timeout <int|float> : Timeout in seconds, random default
  *  --framesize <int> : Frame payload size in bytes, random default
  *  --deflate : Add support for per-message deflate compression
  *  --debug : Output log data (if logger is available)
@@ -58,7 +58,7 @@ while (true) {
     /**
      * @var array{
      *     uri: string,
-     *     timeout: int<0, max>,
+     *     timeout: int<0, max>|float,
      *     framesize: int<1, max>,
      *     deflate: bool,
      *     debug: bool,
@@ -143,8 +143,9 @@ while (true) {
             }
         })->start();
     } catch (Throwable $e) {
+        $wait = rand(1, 10);
         echo "> ERROR: {$e->getMessage()}\n";
-        echo ">        Wait {$options['timeout']} seconds for next attempt.\n";
-        sleep($options['timeout']);
+        echo ">        Wait {$wait} seconds for next attempt.\n";
+        sleep($wait);
     }
 }

--- a/examples/random_server.php
+++ b/examples/random_server.php
@@ -12,7 +12,7 @@
  * Console options:
  *  --port <int> : The port to listen to, default 80
  *  --ssl : Use SSL, default false
- *  --timeout <int> : Timeout in seconds, random default
+ *  --timeout <int|float> : Timeout in seconds, random default
  *  --framesize <int> : Frame payload size in bytes, random default
  *  --connections <int> : Max number of connections, default unlimited
  *  --deflate : Add support for per-message deflate compression
@@ -58,7 +58,7 @@ echo "# Random server\n";
  * @var array{
  *     port: int<1, 32768>,
  *     ssl: bool,
- *     timeout: int<0, max>,
+ *     timeout: int<0, max>|float,
  *     framesize: int<1, max>,
  *     connections: int<0, max>|null,
  *     deflate: bool,

--- a/examples/send.php
+++ b/examples/send.php
@@ -12,7 +12,7 @@
  * Console options:
  *  --uri <uri> : The URI to connect to, default ws://localhost:80
  *  --opcode <string> : Opcode to send, default 'text'
- *  --timeout <int> : Timeout in seconds
+ *  --timeout <int|float> : Timeout in seconds
  *  --framesize <int> : Frame payload size in bytes
  *  --deflate : Add support for per-message deflate compression
  *  --debug : Output log data (if logger is available)
@@ -40,7 +40,7 @@ echo "# Send client! [phrity/websocket]\n";
  * @var array{
  *     uri: string,
  *     opcode: string,
- *     timeout: int<0, max>,
+ *     timeout: int<0, max>|float,
  *     framesize: int<1, max>,
  *     deflate: bool,
  *     debug: bool,

--- a/src/Client.php
+++ b/src/Client.php
@@ -60,8 +60,8 @@ class Client implements LoggerAwareInterface, Stringable
     use StringableTrait;
 
     // Settings
-    /** @var int<0, max> $timeout */
-    private int $timeout = 60;
+    /** @var int<0, max>|float $timeout */
+    private int|float $timeout = 60;
     /** @var int<1, max> $frameSize */
     private int $frameSize = 4096;
     private bool $persistent = false;
@@ -129,11 +129,11 @@ class Client implements LoggerAwareInterface, Stringable
 
     /**
      * Set timeout.
-     * @param int<0, max> $timeout Timeout in seconds
+     * @param int<0, max>|float $timeout Timeout in seconds
      * @return self
      * @throws InvalidArgumentException If invalid timeout provided
      */
-    public function setTimeout(int $timeout): self
+    public function setTimeout(int|float $timeout): self
     {
         if ($timeout < 0) {
             throw new InvalidArgumentException("Invalid timeout '{$timeout}' provided");
@@ -147,9 +147,9 @@ class Client implements LoggerAwareInterface, Stringable
 
     /**
      * Get timeout.
-     * @return int Timeout in seconds
+     * @return int<0, max>|float Timeout in seconds
      */
-    public function getTimeout(): int
+    public function getTimeout(): int|float
     {
         return $this->timeout;
     }
@@ -274,7 +274,7 @@ class Client implements LoggerAwareInterface, Stringable
      * Start client listener.
      * @throws Throwable On low level error
      */
-    public function start(): void
+    public function start(int|float|null $timeout = null): void
     {
         // Check if running
         if ($this->running) {
@@ -292,7 +292,7 @@ class Client implements LoggerAwareInterface, Stringable
         while ($this->running) {
             try {
                 // Get streams with readable content
-                $readables = $streams->waitRead($this->timeout);
+                $readables = $streams->waitRead($timeout ?? $this->timeout);
                 foreach ($readables as $key => $readable) {
                     try {
                         // Read from connection
@@ -391,7 +391,7 @@ class Client implements LoggerAwareInterface, Stringable
         $this->disconnect();
         $this->streams = $this->streamFactory->createStreamCollection();
 
-        $host_uri = (new Uri())
+        $hostUri = (new Uri())
             ->withScheme(match ($this->socketUri->getScheme()) {
                 'ws', 'http' => 'tcp',
                 'wss', 'https' => 'ssl',
@@ -403,18 +403,18 @@ class Client implements LoggerAwareInterface, Stringable
         $stream = null;
 
         try {
-            $client = $this->streamFactory->createSocketClient($host_uri, $this->context);
+            $client = $this->streamFactory->createSocketClient($hostUri, $this->context);
             $client->setPersistent($this->persistent);
             $client->setTimeout($this->timeout);
             $stream = $client->connect();
         } catch (Throwable $e) {
-            $error = "Could not open socket to \"{$host_uri}\": {$e->getMessage()}";
+            $error = "Could not open socket to \"{$hostUri}\": {$e->getMessage()}";
             $this->logger->error("[client] {$error}", ['exception' => $e]);
             throw new ClientException($error);
         }
         $name = $stream->getRemoteName();
         $this->streams->attach($stream, $name);
-        $this->connection = new Connection($stream, true, false, $host_uri->getScheme() === 'ssl');
+        $this->connection = new Connection($stream, true, false, $hostUri->getScheme() === 'ssl');
         $this->connection->setFrameSize($this->frameSize);
         $this->connection->setTimeout($this->timeout);
         $this->connection->setLogger($this->logger);
@@ -423,7 +423,7 @@ class Client implements LoggerAwareInterface, Stringable
         }
 
         if (!$this->isConnected()) {
-            $error = "Invalid stream on \"{$host_uri}\".";
+            $error = "Invalid stream on \"{$hostUri}\".";
             $this->logger->error("[client] {$error}");
             throw new ClientException($error);
         }
@@ -550,12 +550,12 @@ class Client implements LoggerAwareInterface, Stringable
                 );
             }
 
-            $response_key = trim($response->getHeaderLine('Sec-WebSocket-Accept'));
-            $expected_key = base64_encode(
+            $responseKey = trim($response->getHeaderLine('Sec-WebSocket-Accept'));
+            $expectedKey = base64_encode(
                 pack('H*', sha1($key . Constant::GUID))
             );
 
-            if ($response_key !== $expected_key) {
+            if ($responseKey !== $expectedKey) {
                 throw new HandshakeException("Server sent bad upgrade response.", $response);
             }
         } catch (HandshakeException $e) {
@@ -593,24 +593,24 @@ class Client implements LoggerAwareInterface, Stringable
     {
         try {
             if ($uri instanceof Uri) {
-                $uri_instance = $uri;
+                $uriInstance = $uri;
             } elseif ($uri instanceof UriInterface) {
-                $uri_instance = new Uri("{$uri}");
+                $uriInstance = new Uri("{$uri}");
             } else {
-                $uri_instance = new Uri($uri);
+                $uriInstance = new Uri($uri);
             }
         } catch (InvalidArgumentException $e) {
             throw new BadUriException("Invalid URI '{$uri}' provided.");
         }
 
 
-        if (!in_array($uri_instance->getScheme(), ['ws', 'wss'])) {
+        if (!in_array($uriInstance->getScheme(), ['ws', 'wss'])) {
             throw new BadUriException("Invalid URI scheme, must be 'ws' or 'wss'.");
         }
-        if (!$uri_instance->getHost()) {
+        if (!$uriInstance->getHost()) {
             throw new BadUriException("Invalid URI host.");
         }
-        return $uri_instance;
+        return $uriInstance;
     }
 
     protected function connection(): Connection

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -62,8 +62,8 @@ class Connection implements LoggerAwareInterface, Stringable
     private MiddlewareHandler $middlewareHandler;
     /** @var int<1, max> $frameSize */
     private int $frameSize = 4096;
-    /** @var int<0, max> $timeout */
-    private int $timeout = 60;
+    /** @var int<0, max>|float $timeout */
+    private int|float $timeout = 60;
     private string $localName;
     private string $remoteName;
     private RequestInterface|null $handshakeRequest = null;
@@ -116,25 +116,25 @@ class Connection implements LoggerAwareInterface, Stringable
 
     /**
      * Set time out on connection.
-     * @param int<0, max> $timeout Timeout part in seconds
+     * @param int<0, max>|float $timeout Timeout part in seconds
      * @return self
      */
-    public function setTimeout(int $timeout): self
+    public function setTimeout(int|float $timeout): self
     {
         if ($timeout < 0) {
             throw new InvalidArgumentException("Invalid timeout '{$timeout}' provided");
         }
         $this->timeout = $timeout;
-        $this->stream->setTimeout($timeout, 0);
+        $this->stream->setTimeout($timeout);
         $this->logger->debug("[connection] Setting timeout: {$timeout} seconds");
         return $this;
     }
 
     /**
      * Get timeout.
-     * @return int Timeout in seconds.
+     * @return int<0, max>|float Timeout in seconds.
      */
-    public function getTimeout(): int
+    public function getTimeout(): int|float
     {
         return $this->timeout;
     }

--- a/src/Frame/FrameHandler.php
+++ b/src/Frame/FrameHandler.php
@@ -45,47 +45,47 @@ class FrameHandler implements LoggerAwareInterface, Stringable
     {
         // Read the frame "header" first, two bytes.
         $data = $this->read(2);
-        list ($byte_1, $byte_2) = array_values($this->unpack('C*', $data));
-        $final = (bool)($byte_1 & 0b10000000); // Final fragment marker.
-        $rsv1 = (bool)($byte_1 & 0b01000000);
-        $rsv2 = (bool)($byte_1 & 0b00100000);
-        $rsv3 = (bool)($byte_1 & 0b00010000);
+        list ($byte1, $byte2) = array_values($this->unpack('C*', $data));
+        $final = (bool)($byte1 & 0b10000000); // Final fragment marker.
+        $rsv1 = (bool)($byte1 & 0b01000000);
+        $rsv2 = (bool)($byte1 & 0b00100000);
+        $rsv3 = (bool)($byte1 & 0b00010000);
 
         // Parse opcode
-        $opcode_int = $byte_1 & 0b00001111;
-        $opcode_ints = array_flip(self::$opcodes);
-        $opcode = array_key_exists($opcode_int, $opcode_ints) ? $opcode_ints[$opcode_int] : strval($opcode_int);
+        $opcodeInt = $byte1 & 0b00001111;
+        $opcodeInts = array_flip(self::$opcodes);
+        $opcode = array_key_exists($opcodeInt, $opcodeInts) ? $opcodeInts[$opcodeInt] : strval($opcodeInt);
 
         // Masking bit
-        $masked = (bool)($byte_2 & 0b10000000);
+        $masked = (bool)($byte2 & 0b10000000);
 
         $payload = '';
 
         // Payload length
-        $payload_length = $byte_2 & 0b01111111;
+        $payloadLength = $byte2 & 0b01111111;
 
-        if ($payload_length > 125) {
-            if ($payload_length === 126) {
+        if ($payloadLength > 125) {
+            if ($payloadLength === 126) {
                 $data = $this->read(2); // 126: Payload length is a 16-bit unsigned int
-                $payload_length = current($this->unpack('n', $data));
+                $payloadLength = current($this->unpack('n', $data));
             } else {
                 $data = $this->read(8); // 127: Payload length is a 64-bit unsigned int
-                $payload_length = current($this->unpack('J', $data));
+                $payloadLength = current($this->unpack('J', $data));
             }
         }
 
         // Get masking key.
         if ($masked) {
-            $masking_key = $this->stream->read(4);
+            $maskingKey = $this->stream->read(4);
         }
 
         // Get the actual payload, if any (might not be for e.g. close frames).
-        if ($payload_length > 0) {
-            $data = $this->read($payload_length);
+        if ($payloadLength > 0) {
+            $data = $this->read($payloadLength);
             if ($masked) {
                 // Unmask payload.
-                for ($i = 0; $i < $payload_length; $i++) {
-                    $payload .= ($data[$i] ^ $masking_key[$i % 4]);
+                for ($i = 0; $i < $payloadLength; $i++) {
+                    $payload .= ($data[$i] ^ $maskingKey[$i % 4]);
                 }
             } else {
                 $payload = $data;
@@ -111,27 +111,27 @@ class FrameHandler implements LoggerAwareInterface, Stringable
     public function push(Frame $frame): int
     {
         $payload = $frame->getPayload();
-        $payload_length = $frame->getPayloadLength();
+        $payloadLength = $frame->getPayloadLength();
 
         $data = '';
-        $byte_1 = $frame->isFinal() ? 0b10000000 : 0b00000000; // Final fragment marker.
-        $byte_1 |= $frame->getRsv1() ? 0b01000000 : 0b00000000; // RSV1 bit.
-        $byte_1 |= $frame->getRsv2() ? 0b00100000 : 0b00000000; // RSV2 bit.
-        $byte_1 |= $frame->getRsv3() ? 0b00010000 : 0b00000000; // RSV3 bit.
-        $byte_1 |= self::$opcodes[$frame->getOpcode()]; // Set opcode.
-        $data .= pack('C', $byte_1);
+        $byte1 = $frame->isFinal() ? 0b10000000 : 0b00000000; // Final fragment marker.
+        $byte1 |= $frame->getRsv1() ? 0b01000000 : 0b00000000; // RSV1 bit.
+        $byte1 |= $frame->getRsv2() ? 0b00100000 : 0b00000000; // RSV2 bit.
+        $byte1 |= $frame->getRsv3() ? 0b00010000 : 0b00000000; // RSV3 bit.
+        $byte1 |= self::$opcodes[$frame->getOpcode()]; // Set opcode.
+        $data .= pack('C', $byte1);
 
-        $byte_2 = $this->pushMasked ? 0b10000000 : 0b00000000; // Masking bit marker.
+        $byte2 = $this->pushMasked ? 0b10000000 : 0b00000000; // Masking bit marker.
 
         // 7 bits of payload length
-        if ($payload_length > 65535) {
-            $data .= pack('C', $byte_2 | 0b01111111);
-            $data .= pack('J', $payload_length);
-        } elseif ($payload_length > 125) {
-            $data .= pack('C', $byte_2 | 0b01111110);
-            $data .= pack('n', $payload_length);
+        if ($payloadLength > 65535) {
+            $data .= pack('C', $byte2 | 0b01111111);
+            $data .= pack('J', $payloadLength);
+        } elseif ($payloadLength > 125) {
+            $data .= pack('C', $byte2 | 0b01111110);
+            $data .= pack('n', $payloadLength);
         } else {
-            $data .= pack('C', $byte_2 | $payload_length);
+            $data .= pack('C', $byte2 | $payloadLength);
         }
 
         // Handle masking.
@@ -144,7 +144,7 @@ class FrameHandler implements LoggerAwareInterface, Stringable
             $data .= $mask;
 
             // Append masked payload to frame.
-            for ($i = 0; $i < $payload_length; $i++) {
+            for ($i = 0; $i < $payloadLength; $i++) {
                 $data .= $payload[$i] ^ $mask[$i % 4];
             }
         } else {
@@ -163,13 +163,18 @@ class FrameHandler implements LoggerAwareInterface, Stringable
         return $written;
     }
 
-    // Secured read op
+    /**
+     * Secured read op
+     * @param int<1, max> $length
+     */
     private function read(int $length): string
     {
         $data = '';
         $read = 0;
         while ($read < $length) {
-            $got = $this->stream->read($length - $read);
+            /** @var int<1, max> $readLength */
+            $readLength = $length - $read;
+            $got = $this->stream->read($readLength);
             if (empty($got)) {
                 throw new RuntimeException('Empty read; connection dead?');
             }

--- a/src/Message/Close.php
+++ b/src/Message/Close.php
@@ -34,12 +34,12 @@ class Close extends Message
 
     public function getPayload(): string
     {
-        $status_binstr = sprintf('%016b', $this->status);
-        $status_str = '';
-        foreach (str_split($status_binstr, 8) as $binstr) {
-            $status_str .= chr((int)bindec($binstr));
+        $statusBinstr = sprintf('%016b', $this->status);
+        $statusStr = '';
+        foreach (str_split($statusBinstr, 8) as $binstr) {
+            $statusStr .= chr((int)bindec($binstr));
         }
-        return $status_str . $this->content;
+        return $statusStr . $this->content;
     }
 
     public function setPayload(string $payload = ''): void

--- a/src/Middleware/PingInterval.php
+++ b/src/Middleware/PingInterval.php
@@ -28,9 +28,9 @@ class PingInterval implements LoggerAwareInterface, ProcessOutgoingInterface, Pr
     use LoggerAwareTrait;
     use StringableTrait;
 
-    private int|null $interval;
+    private int|float|null $interval;
 
-    public function __construct(int|null $interval = null)
+    public function __construct(int|float|null $interval = null)
     {
         $this->interval = $interval;
         $this->initLogger();
@@ -45,7 +45,7 @@ class PingInterval implements LoggerAwareInterface, ProcessOutgoingInterface, Pr
     public function processTick(ProcessTickStack $stack, Connection $connection): void
     {
         // Push if time exceeds timestamp for next ping
-        if ($connection->isWritable() && time() >= $this->getNext($connection)) {
+        if ($connection->isWritable() && microtime(true) >= $this->getNext($connection)) {
             $this->logger->debug("[ping-interval] Auto-pushing ping");
             $connection->send(new Ping());
             $this->setNext($connection); // Update timestamp for next ping
@@ -53,14 +53,14 @@ class PingInterval implements LoggerAwareInterface, ProcessOutgoingInterface, Pr
         $stack->handleTick();
     }
 
-    private function getNext(Connection $connection): int
+    private function getNext(Connection $connection): float
     {
         return $connection->getMeta('pingInterval.next') ?? $this->setNext($connection);
     }
 
-    private function setNext(Connection $connection): int
+    private function setNext(Connection $connection): float
     {
-        $next = time() + ($this->interval ?? $connection->getTimeout());
+        $next = microtime(true) + ($this->interval ?? $connection->getTimeout());
         $connection->setMeta('pingInterval.next', $next);
         return $next;
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -60,8 +60,8 @@ class Server implements LoggerAwareInterface, Stringable
     // Settings
     private int $port;
     private string $scheme;
-    /** @var int<0, max> $timeout */
-    private int $timeout = 60;
+    /** @var int<0, max>|float $timeout */
+    private int|float $timeout = 60;
     /** @var int<1, max> $frameSize */
     private int $frameSize = 4096;
     private Context $context;
@@ -134,11 +134,11 @@ class Server implements LoggerAwareInterface, Stringable
 
     /**
      * Set timeout.
-     * @param int<0, max> $timeout Timeout in seconds
+     * @param int<0, max>|float $timeout Timeout in seconds
      * @return self
      * @throws InvalidArgumentException If invalid timeout provided
      */
-    public function setTimeout(int $timeout): self
+    public function setTimeout(int|float $timeout): self
     {
         if ($timeout < 0) {
             throw new InvalidArgumentException("Invalid timeout '{$timeout}' provided");
@@ -152,9 +152,9 @@ class Server implements LoggerAwareInterface, Stringable
 
     /**
      * Get timeout.
-     * @return int Timeout in seconds
+     * @return int<0, max>|float Timeout in seconds
      */
-    public function getTimeout(): int
+    public function getTimeout(): int|float
     {
         return $this->timeout;
     }
@@ -332,7 +332,7 @@ class Server implements LoggerAwareInterface, Stringable
      * Start server listener.
      * @throws Throwable On low level error
      */
-    public function start(): void
+    public function start(int|float|null $timeout = null): void
     {
         // Create socket server
         if (empty($this->server)) {
@@ -361,7 +361,7 @@ class Server implements LoggerAwareInterface, Stringable
                 }
 
                 // Get streams with readable content
-                $readables = $this->streams->waitRead($this->timeout);
+                $readables = $this->streams->waitRead($timeout ?? $this->timeout);
                 foreach ($readables as $key => $readable) {
                     try {
                         $connection = null;

--- a/tests/mock/EchoLog.php
+++ b/tests/mock/EchoLog.php
@@ -27,8 +27,8 @@ class EchoLog implements LoggerInterface
     public function log($level, $message, array $context = [])
     {
         $message = $this->interpolate($message, $context);
-        $context_string = json_encode($this->context($context), self::FLAGS);
-        echo str_pad($level, 8) . " | {$message} {$context_string}\n";
+        $contextString = json_encode($this->context($context), self::FLAGS);
+        echo str_pad($level, 8) . " | {$message} {$contextString}\n";
     }
 
     /** @param array<string, mixed> $context */

--- a/tests/mock/MockStreamTrait.php
+++ b/tests/mock/MockStreamTrait.php
@@ -33,7 +33,7 @@ trait MockStreamTrait
 
     /** @var array<StackItem> $stack */
     private array $stack = [];
-    private string $last_ws_key = '';
+    private string $lastWsKey = '';
 
 
     /* ---------- WebSocket Client combinded asserts --------------------------------------------------------------- */
@@ -45,7 +45,7 @@ trait MockStreamTrait
         string $scheme = 'tcp',
         string $host = 'localhost',
         int $port = 8000,
-        int $timeout = 60,
+        int|float $timeout = 60,
         array $context = [],
         bool $persistent = false,
     ): void {
@@ -76,7 +76,7 @@ trait MockStreamTrait
         string $scheme = 'tcp',
         string $host = 'localhost',
         int $port = 8000,
-        int $timeout = 60,
+        int|float $timeout = 60,
         array $context = [],
         bool $persistent = false,
         string $local = '127.0.0.1:12345',
@@ -102,7 +102,6 @@ trait MockStreamTrait
 
         $this->expectSocketStreamSetTimeout()->addAssert(function ($method, $params) use ($timeout) {
             $this->assertEquals($timeout, $params[0]);
-            $this->assertEquals(0, $params[1]);
         });
         $this->expectSocketStreamIsConnected();
         if ($persistent) {
@@ -118,10 +117,10 @@ trait MockStreamTrait
         $this->expectSocketStreamWrite()->addAssert(
             function (string $method, array $params) use ($host, $path, $headers): void {
                 preg_match('/Sec-WebSocket-Key: ([\S]*)\r\n/', $params[0], $m);
-                $this->last_ws_key = $m[1] ?? '';
+                $this->lastWsKey = $m[1] ?? '';
                 $this->assertEquals(
                     "GET {$path} HTTP/1.1\r\nHost: {$host}\r\nUser-Agent: websocket-client-php\r\nConnection: Upgrade"
-                    . "\r\nUpgrade: websocket\r\nSec-WebSocket-Key: {$this->last_ws_key}\r\nSec-WebSocket-Version: 13"
+                    . "\r\nUpgrade: websocket\r\nSec-WebSocket-Key: {$this->lastWsKey}\r\nSec-WebSocket-Version: 13"
                     . "\r\n{$headers}\r\n",
                     $params[0]
                 );
@@ -145,8 +144,8 @@ trait MockStreamTrait
         $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
             $this->assertEquals(1024, $params[0]);
         })->setReturn(function (array $params) {
-            $ws_key_res = base64_encode(pack('H*', sha1($this->last_ws_key . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')));
-            return "Sec-WebSocket-Accept: {$ws_key_res}\r\n\r\n";
+            $wsKeyRes = base64_encode(pack('H*', sha1($this->lastWsKey . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')));
+            return "Sec-WebSocket-Accept: {$wsKeyRes}\r\n\r\n";
         });
         $this->expectSocketStreamReadLine()->addAssert(function (string $method, array $params): void {
             $this->assertEquals(1024, $params[0]);

--- a/tests/suites/client/ConfigErrorTest.php
+++ b/tests/suites/client/ConfigErrorTest.php
@@ -77,7 +77,6 @@ class ConfigErrorTest extends TestCase
         $client = new Client('ws://localhost:8000/my/mock/path');
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid timeout '-10' provided");
-        // @phpstan-ignore argument.type
         $client->setTimeout(-10);
     }
 

--- a/tests/suites/client/ConfigTest.php
+++ b/tests/suites/client/ConfigTest.php
@@ -27,6 +27,7 @@ use WebSocket\{
     Client,
     Connection,
 };
+use WebSocket\Middleware\CloseHandler;
 use WebSocket\Test\{
     MockStreamTrait,
     MockUri
@@ -315,11 +316,10 @@ class ConfigTest extends TestCase
         $client->connect();
 
         $client->setLogger(new NullLogger());
-        $client->addMiddleware(new \WebSocket\Middleware\CloseHandler());
+        $client->addMiddleware(new CloseHandler());
 
         $this->expectSocketStreamSetTimeout()->addAssert(function ($method, $params) {
             $this->assertEquals(300, $params[0]);
-            $this->assertEquals(0, $params[1]);
         });
         $client->setTimeout(300);
 

--- a/tests/suites/client/HandshakeTest.php
+++ b/tests/suites/client/HandshakeTest.php
@@ -93,7 +93,7 @@ class HandshakeTest extends TestCase
         $this->expectSocketStreamWrite()->addAssert(
             function (string $method, array $params): void {
                 preg_match('/Sec-WebSocket-Key: ([\S]*)\r\n/', $params[0], $m);
-                $this->last_ws_key = $m[1] ?? '';
+                $this->lastWsKey = $m[1] ?? '';
             }
         );
         $this->expectSocketStreamReadLine()->setReturn(function (array $params) {
@@ -106,8 +106,8 @@ class HandshakeTest extends TestCase
             return "Connection: keep-alive, upgrade\r\n";
         });
         $this->expectSocketStreamReadLine()->setReturn(function (array $params) {
-            $ws_key_res = base64_encode(pack('H*', sha1($this->last_ws_key . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')));
-            return "Sec-WebSocket-Accept: {$ws_key_res}\r\n\r\n";
+            $wsKeyRes = base64_encode(pack('H*', sha1($this->lastWsKey . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')));
+            return "Sec-WebSocket-Accept: {$wsKeyRes}\r\n\r\n";
         });
         $this->expectSocketStreamReadLine()->setReturn(function (array $params) {
             return "\r\n";

--- a/tests/suites/connection/ConnectionTest.php
+++ b/tests/suites/connection/ConnectionTest.php
@@ -73,9 +73,9 @@ class ConnectionTest extends TestCase
         $this->expectSocketStreamIsConnected();
         $this->assertTrue($connection->isConnected());
 
-        $this->assertEquals('', $connection->getName());
-        $this->assertEquals('', $connection->getRemoteName());
-        $this->assertEquals('WebSocket\Connection(:)', "{$connection}");
+        $this->assertEquals('<unknown>', $connection->getName());
+        $this->assertEquals('<unknown>', $connection->getRemoteName());
+        $this->assertEquals('WebSocket\Connection(<unknown>:<unknown>)', "{$connection}");
         $connection->tick();
         $connection->setMeta('test.meta.1', 'meta.data.1');
         $connection->setMeta('test.meta.2', 'meta.data.2');

--- a/tests/suites/connection/ExceptionTest.php
+++ b/tests/suites/connection/ExceptionTest.php
@@ -294,7 +294,6 @@ class ExceptionTest extends TestCase
         $this->expectExceptionMessage("Invalid timeout '-1' provided");
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamClose();
-        // @phpstan-ignore argument.type
         $connection->setTimeout(-1);
 
         unset($connection);

--- a/tests/suites/http/RequestTest.php
+++ b/tests/suites/http/RequestTest.php
@@ -96,105 +96,105 @@ class RequestTest extends TestCase
     public function testImmutability(): void
     {
         $request = new Request();
-        $request_clone = $request->withRequestTarget('/new/path?c=d');
-        $this->assertNotSame($request_clone, $request);
-        $this->assertEquals('/new/path?c=d', $request_clone->getRequestTarget());
+        $requestClone = $request->withRequestTarget('/new/path?c=d');
+        $this->assertNotSame($requestClone, $request);
+        $this->assertEquals('/new/path?c=d', $requestClone->getRequestTarget());
 
-        $request_clone = $request->withMethod('POST');
-        $this->assertNotSame($request_clone, $request);
-        $this->assertEquals('POST', $request_clone->getMethod());
+        $requestClone = $request->withMethod('POST');
+        $this->assertNotSame($requestClone, $request);
+        $this->assertEquals('POST', $requestClone->getMethod());
 
-        $request_clone = $request->withUri(new Uri('ws://test.com:123/a/path?a=b'));
-        $this->assertNotSame($request_clone, $request);
-        $this->assertEquals('/a/path?a=b', $request_clone->getRequestTarget());
-        $this->assertEquals(['Host' => ['test.com:123']], $request_clone->getHeaders());
+        $requestClone = $request->withUri(new Uri('ws://test.com:123/a/path?a=b'));
+        $this->assertNotSame($requestClone, $request);
+        $this->assertEquals('/a/path?a=b', $requestClone->getRequestTarget());
+        $this->assertEquals(['Host' => ['test.com:123']], $requestClone->getHeaders());
 
-        $request_clone = $request->withProtocolVersion('1.0');
-        $this->assertNotSame($request_clone, $request);
-        $this->assertEquals('1.0', $request_clone->getProtocolVersion());
+        $requestClone = $request->withProtocolVersion('1.0');
+        $this->assertNotSame($requestClone, $request);
+        $this->assertEquals('1.0', $requestClone->getProtocolVersion());
 
-        $request_clone = $request->withHeader('Test-Header', 'Test-Value');
-        $this->assertNotSame($request_clone, $request);
-        $this->assertEquals(['Test-Value'], $request_clone->getHeader('Test-Header'));
+        $requestClone = $request->withHeader('Test-Header', 'Test-Value');
+        $this->assertNotSame($requestClone, $request);
+        $this->assertEquals(['Test-Value'], $requestClone->getHeader('Test-Header'));
     }
 
     public function testHeaders(): void
     {
-        $request_1 = new Request('GET', 'ws://test.com:123/a/path?a=b');
+        $request1 = new Request('GET', 'ws://test.com:123/a/path?a=b');
         $this->assertEquals([
             'Host' => ['test.com:123'],
-        ], $request_1->getHeaders());
+        ], $request1->getHeaders());
         $this->assertEquals([
             'GET /a/path?a=b HTTP/1.1',
             'Host: test.com:123',
-        ], $request_1->getAsArray());
+        ], $request1->getAsArray());
 
-        $request_2 = $request_1->withHeader('Test-Header', 'Test-Value-1');
-        $this->assertNotSame($request_2, $request_1);
+        $request2 = $request1->withHeader('Test-Header', 'Test-Value-1');
+        $this->assertNotSame($request2, $request1);
         $this->assertEquals([
             'Host' => ['test.com:123'],
             'Test-Header' => ['Test-Value-1'],
-        ], $request_2->getHeaders());
+        ], $request2->getHeaders());
         $this->assertEquals([
             'GET /a/path?a=b HTTP/1.1',
             'Host: test.com:123',
             'Test-Header: Test-Value-1',
-        ], $request_2->getAsArray());
+        ], $request2->getAsArray());
 
-        $request_3 = $request_2->withHeader('Test-Header', 'Test-Value-2');
-        $this->assertNotSame($request_3, $request_2);
+        $request3 = $request2->withHeader('Test-Header', 'Test-Value-2');
+        $this->assertNotSame($request3, $request2);
         $this->assertEquals([
             'Host' => ['test.com:123'],
             'Test-Header' => ['Test-Value-2'],
-        ], $request_3->getHeaders());
+        ], $request3->getHeaders());
         $this->assertEquals([
             'GET /a/path?a=b HTTP/1.1',
             'Host: test.com:123',
             'Test-Header: Test-Value-2',
-        ], $request_3->getAsArray());
+        ], $request3->getAsArray());
 
-        $request_4 = $request_3->withAddedHeader('Test-Header', 'Test-Value-3');
-        $this->assertNotSame($request_4, $request_3);
+        $request4 = $request3->withAddedHeader('Test-Header', 'Test-Value-3');
+        $this->assertNotSame($request4, $request3);
         $this->assertEquals([
             'Host' => ['test.com:123'],
             'Test-Header' => ['Test-Value-2', 'Test-Value-3'],
-        ], $request_4->getHeaders());
+        ], $request4->getHeaders());
         $this->assertEquals([
             'GET /a/path?a=b HTTP/1.1',
             'Host: test.com:123',
             'Test-Header: Test-Value-2',
             'Test-Header: Test-Value-3',
-        ], $request_4->getAsArray());
+        ], $request4->getAsArray());
 
-        $request_5 = $request_4->withoutHeader('Test-Header');
-        $this->assertNotSame($request_5, $request_4);
+        $request5 = $request4->withoutHeader('Test-Header');
+        $this->assertNotSame($request5, $request4);
         $this->assertEquals([
             'Host' => ['test.com:123'],
-        ], $request_5->getHeaders());
+        ], $request5->getHeaders());
         $this->assertEquals([
             'GET /a/path?a=b HTTP/1.1',
             'Host: test.com:123',
-        ], $request_5->getAsArray());
+        ], $request5->getAsArray());
 
-        $request_6 = $request_5->withUri(new Uri('ws://another.com:456/new/path?a=b'));
-        $this->assertNotSame($request_6, $request_5);
+        $request6 = $request5->withUri(new Uri('ws://another.com:456/new/path?a=b'));
+        $this->assertNotSame($request6, $request5);
         $this->assertEquals([
             'Host' => ['another.com:456'],
-        ], $request_6->getHeaders());
+        ], $request6->getHeaders());
         $this->assertEquals([
             'GET /new/path?a=b HTTP/1.1',
             'Host: another.com:456',
-        ], $request_6->getAsArray());
+        ], $request6->getAsArray());
 
-        $request_7 = $request_6->withUri(new Uri('ws://yetanother.com:789/new/path?a=b'), true);
-        $this->assertNotSame($request_7, $request_6);
+        $request7 = $request6->withUri(new Uri('ws://yetanother.com:789/new/path?a=b'), true);
+        $this->assertNotSame($request7, $request6);
         $this->assertEquals([
             'Host' => ['another.com:456'],
-        ], $request_7->getHeaders());
+        ], $request7->getHeaders());
         $this->assertEquals([
             'GET /new/path?a=b HTTP/1.1',
             'Host: another.com:456',
-        ], $request_6->getAsArray());
+        ], $request6->getAsArray());
     }
 
     public function testGetBodyError(): void

--- a/tests/suites/http/ResponseTest.php
+++ b/tests/suites/http/ResponseTest.php
@@ -80,22 +80,22 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
 
-        $response_clone = $response->withProtocolVersion('1.0');
-        $this->assertNotSame($response_clone, $response);
-        $this->assertEquals('1.0', $response_clone->getProtocolVersion());
+        $responseClone = $response->withProtocolVersion('1.0');
+        $this->assertNotSame($responseClone, $response);
+        $this->assertEquals('1.0', $responseClone->getProtocolVersion());
 
-        $response_clone = $response->withStatus(500);
-        $this->assertNotSame($response_clone, $response);
-        $this->assertEquals(500, $response_clone->getStatusCode());
-        $this->assertEquals('Internal Server Error', $response_clone->getReasonPhrase());
+        $responseClone = $response->withStatus(500);
+        $this->assertNotSame($responseClone, $response);
+        $this->assertEquals(500, $responseClone->getStatusCode());
+        $this->assertEquals('Internal Server Error', $responseClone->getReasonPhrase());
 
-        $response_clone = $response->withHeader('Test-Header', 'Test-Value');
-        $this->assertNotSame($response_clone, $response);
-        $this->assertEquals(['Test-Value'], $response_clone->getHeader('Test-Header'));
+        $responseClone = $response->withHeader('Test-Header', 'Test-Value');
+        $this->assertNotSame($responseClone, $response);
+        $this->assertEquals(['Test-Value'], $responseClone->getHeader('Test-Header'));
         $this->assertEquals([
             'HTTP/1.1 200 OK',
             'Test-Header: Test-Value',
-        ], $response_clone->getAsArray());
+        ], $responseClone->getAsArray());
     }
 
     public function testConstructStatusError(): void

--- a/tests/suites/server/ConfigErrorTest.php
+++ b/tests/suites/server/ConfigErrorTest.php
@@ -45,7 +45,6 @@ class ConfigErrorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage("Invalid timeout '-1' provided");
-        // @phpstan-ignore argument.type
         $server->setTimeout(-1);
     }
 


### PR DESCRIPTION
* Timeouts support float
* Client and Server `start()` can have specific timeout
* Using `phrity/net-stream ^2.3`
