### PR TITLE
Fuzzy header parsing deflate compression

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ Please provide a clear and concise description of the suspected issue.
 If possible, provide information - possibly including code snippets - on how to reproduce the issue.
 
 **Logs**
-If possible, provide logs that indicate the issue. See https://github.com/Textalk/websocket-php/blob/master/docs/Examples.md#logger on how to use a logger.
+If possible, provide logs that indicate the issue. See [Examples: Logger](../../docs/Examples.md#logger) on how to use a logger.
 
 **Versions**
 * Version of this library

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ and is maintained by Sören Jensen, who has been maintaining the original since 
 * [Changelog](docs/Changelog.md) - The changelog of this repo
 * [Contributing](docs/Contributing.md) - Contributors and requirements
 * [Examples](docs/Examples.md) - Examples
+
+## Migration
+
+* [v1 -> v2](docs/Migrate_1_2.md) - How to migrate from v1 to v2
 * [v2 -> v3](docs/Migrate_2_3.md) - How to migrate from v2 to v3
 
 ## Installing

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,11 @@
 
  > PHP version `^8.1`
 
+### `3.6.2`
+
+ * Deflate compression fuzzy header parsing fix (@sirn-se)
+ * More documentation (@sirn-se)
+
 ### `3.6.1`
 
  * Fix typos and broken links (@pieterocp)

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -104,3 +104,4 @@ make stan
 * Pieter Oliver
 * Sebastian Hagens
 * Adrian Mihai
+* Pieter Oliver

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -22,4 +22,5 @@
 
 ## Migration
 
+* [v1 -> v2](Migrate_1_2.md) - How to migrate from v1 to v2
 * [v2 -> v3](Migrate_2_3.md) - How to migrate from v2 to v3

--- a/docs/Migrate_1_2.md
+++ b/docs/Migrate_1_2.md
@@ -1,0 +1,56 @@
+[Documentation](Index.md) / Migration v1 -> v2
+
+# Websocket: Migration v1 -> v2
+
+Version `2.x` has significant changes compared to previous version.
+Amongst other things, it introduces callback listeners, middleware support, and the Server now support multiple connections.
+
+## Constructor and configuration
+
+Where `1.x` was configured by using an array of options on the constructor,
+`2.x` provides a number of configuration methods instead.
+Replace configuration with a call to corresponding method instead.
+
+```php
+new WebSocket\Client(string $uri)
+new WebSocket\Server(bool $ssl, int $port)
+
+setLogger(Psr\Log\LoggerInterface $logger) // logger
+setTimeout(int $timeout) // timeout
+setFrameSize(int $frameSize) // fragment_size
+setPersistent(bool $persistent) // persistent
+setContext(array $context_as_array) // context
+addHeader(string $name, string $value) // headers
+```
+
+The `filter` and `return_obj` are no longer valid.
+
+## Middlewares
+
+`2.x` introduces middlewares to extend functionality to Client and Server.
+Two of the middlewares cover functionality built-in in `1.x` and should be added unless you create your own code instead.
+
+```php
+addMiddleware(new WebSocket\Middleware\CloseHandler())
+addMiddleware(new WebSocket\Middleware\PingResponder())
+```
+
+## Receiving messages
+
+The Client `receive()` method always return an instance of Message (Text, Binary, Ping, Pong or Close).
+This corresponds to setting `return_obj: true` in `1.x` configuration. By default `1.x` returned string.
+
+You are encouraged to read incoming messages using [listener callback methods](https://github.com/sirn-se/websocket-php/blob/2.0.0/docs/Client.md#subscribe-operation) instead.
+
+The Server no longer has the `receive()` method.
+Receiving, use [listener callback methods](https://github.com/sirn-se/websocket-php/blob/2.0.0/docs/Server.md#message-listeners).
+
+## Sending messages
+
+The `send(...)` method no longer accepts message and opcode as strings,
+but only accepts an instance of Message (Text, Binary, Ping, Pong or Close).
+However, there are convenience methods available as `text(...)`, `binary(...)`, `ping(...)`, `pong(...)` and `close(...)`.
+
+## More?
+
+As `2.x` has significant internal code changes, other classes and methods are likely to have changed.

--- a/src/Middleware/CompressionExtension/DeflateCompressor.php
+++ b/src/Middleware/CompressionExtension/DeflateCompressor.php
@@ -149,7 +149,8 @@ class DeflateCompressor implements CompressorInterface, Stringable
         ];
         foreach (explode(';', $element) as $parameter) {
             $parts = explode('=', $parameter);
-            $key = trim($parts[0]);
+            $key = trim(array_shift($parts));
+            $value = array_shift($parts);
             // @todo: Error handling when parsing
             switch ($key) {
                 case 'permessage-deflate':
@@ -162,11 +163,11 @@ class DeflateCompressor implements CompressorInterface, Stringable
                     $configuration->clientNoContextTakeover = true;
                     break;
                 case 'server_max_window_bits':
-                    $bits = intval($parts[1] ?? self::MAX_WINDOW_SIZE);
+                    $bits = $this->intVal($value, self::MAX_WINDOW_SIZE);
                     $configuration->serverMaxWindowBits = min($bits, $this->serverMaxWindowBits);
                     break;
                 case 'client_max_window_bits':
-                    $bits = intval($parts[1] ?? self::MAX_WINDOW_SIZE);
+                    $bits = $this->intVal($value, self::MAX_WINDOW_SIZE);
                     $configuration->clientMaxWindowBits = min($bits, $this->clientMaxWindowBits);
                     break;
             }
@@ -232,5 +233,14 @@ class DeflateCompressor implements CompressorInterface, Stringable
         $message->setCompress(false);
         $message->setPayload($inflated);
         return $message;
+    }
+
+    private function intVal(string|null $input, int $default): int
+    {
+        if (is_null($input)) {
+            return $default;
+        }
+        preg_match('/([1-9][0-9]*)/', $input, $matches);
+        return empty($matches) ? $default : (int)array_shift($matches);
     }
 }

--- a/src/Middleware/CompressionExtension/DeflateCompressor.php
+++ b/src/Middleware/CompressionExtension/DeflateCompressor.php
@@ -163,11 +163,11 @@ class DeflateCompressor implements CompressorInterface, Stringable
                     $configuration->clientNoContextTakeover = true;
                     break;
                 case 'server_max_window_bits':
-                    $bits = $this->intVal($value, self::MAX_WINDOW_SIZE);
+                    $bits = $this->intVal($value);
                     $configuration->serverMaxWindowBits = min($bits, $this->serverMaxWindowBits);
                     break;
                 case 'client_max_window_bits':
-                    $bits = $this->intVal($value, self::MAX_WINDOW_SIZE);
+                    $bits = $this->intVal($value);
                     $configuration->clientMaxWindowBits = min($bits, $this->clientMaxWindowBits);
                     break;
             }
@@ -235,12 +235,16 @@ class DeflateCompressor implements CompressorInterface, Stringable
         return $message;
     }
 
-    private function intVal(string|null $input, int $default): int
+    private function intVal(string|null $input): int
     {
         if (is_null($input)) {
-            return $default;
+            return self::MAX_WINDOW_SIZE;
         }
         preg_match('/([1-9][0-9]*)/', $input, $matches);
-        return empty($matches) ? $default : (int)array_shift($matches);
+        if (empty($matches)) {
+            return self::MAX_WINDOW_SIZE;
+        }
+        $value = (int)array_shift($matches);
+        return min(max($value, self::MIN_WINDOW_SIZE), self::MAX_WINDOW_SIZE);
     }
 }

--- a/tests/suites/middleware/DeflateCompressorTest.php
+++ b/tests/suites/middleware/DeflateCompressorTest.php
@@ -730,6 +730,11 @@ class DeflateCompressorTest extends TestCase
         $configuration = $compressor->getConfiguration($header, false);
         $this->assertSame(15, $configuration->clientMaxWindowBits);
         $this->assertSame(15, $configuration->serverMaxWindowBits);
+
+        $header = 'client_max_window_bits=8;server_max_window_bits=16;';
+        $configuration = $compressor->getConfiguration($header, false);
+        $this->assertSame(9, $configuration->clientMaxWindowBits);
+        $this->assertSame(15, $configuration->serverMaxWindowBits);
     }
 
 

--- a/tests/suites/middleware/DeflateCompressorTest.php
+++ b/tests/suites/middleware/DeflateCompressorTest.php
@@ -712,6 +712,26 @@ class DeflateCompressorTest extends TestCase
         new DeflateCompressor(clientMaxWindowBits: 16);
     }
 
+    public function testHeaderParsing(): void
+    {
+        $compressor = new DeflateCompressor();
+
+        $header = 'client_max_window_bits=10;server_max_window_bits=11;';
+        $configuration = $compressor->getConfiguration($header, false);
+        $this->assertSame(10, $configuration->clientMaxWindowBits);
+        $this->assertSame(11, $configuration->serverMaxWindowBits);
+
+        $header = ' client_max_window_bits = "10" ; server_max_window_bits=\'11\' ; ';
+        $configuration = $compressor->getConfiguration($header, false);
+        $this->assertSame(10, $configuration->clientMaxWindowBits);
+        $this->assertSame(11, $configuration->serverMaxWindowBits);
+
+        $header = 'client_max_window_bits; server_max_window_bits=invalid;';
+        $configuration = $compressor->getConfiguration($header, false);
+        $this->assertSame(15, $configuration->clientMaxWindowBits);
+        $this->assertSame(15, $configuration->serverMaxWindowBits);
+    }
+
 
     /**
      * PhpStan cannot resolve otherwise


### PR DESCRIPTION
According to [rfc7692](https://datatracker.ietf.org/doc/html/rfc7692), compression configuration should be specified as
```
client_max_window_bits=10;server_max_window_bits=11;
```
However real life implementation are not always that strict. PR introduces a more fuzzy way of extracting configuration values, supporting wrapping `'` `"` and extra white spaces.
```
 client_max_window_bits = "10" ; server_max_window_bits='11' ; 
```

Also ensure window size read from headers are in valid range (9-15).
```
client_max_window_bits=8;server_max_window_bits=16;
// client_max_window_bits: 9, server_max_window_bits: 15
```

closes #143 