### PR TITLE
Identity conflict: verify connection is usable

### DIFF
--- a/src/Runtime/Runner.php
+++ b/src/Runtime/Runner.php
@@ -52,7 +52,11 @@ class Runner
     public function attach(StreamContainerInterface $streamContainer, Closure $onSelect, string $identity): void
     {
         if (array_key_exists($identity, $this->containers)) {
-            throw new RunnerException("Stream container with identity {$identity} already attached");
+            // On repeated identity, check if actually readable (detach if not)
+            if ($this->containers[$identity]->stream->isReadable()) {
+                throw new RunnerException("Stream container with identity {$identity} already attached");
+            }
+            $this->detach($identity);
         }
         $stream = $streamContainer->getStream();
         $this->streamCollection->attach($stream, $identity);

--- a/tests/suites/runtime/RunnerTest.php
+++ b/tests/suites/runtime/RunnerTest.php
@@ -62,6 +62,36 @@ class RunnerTest extends TestCase
         $runner->detach($streamContainer->getIdentity());
     }
 
+    public function testIdentityConflictResolvable(): void
+    {
+        $this->expectStreamFactory();
+        $factory = new StreamFactory();
+        $this->expectStreamFactoryCreateStreamCollection();
+        $this->expectStreamCollection();
+        $runner = new Runner($factory);
+
+        $this->expectStreamFactoryCreateStream();
+        $this->expectStreamFactoryCreateStreamFromResource();
+        $this->expectStream();
+        $this->expectStreamGetMetadata();
+        $this->expectContext();
+        $streamContainer = new MockStreamContainer($factory);
+
+        $this->expectStreamCollectionAttach();
+        $runner->attach($streamContainer, function () {
+            // ignore
+        }, $streamContainer->getIdentity());
+
+        $this->expectStreamIsReadable()->setReturn(function () {
+            return false;
+        });
+        $this->expectStreamCollectionDetach();
+        $this->expectStreamCollectionAttach();
+        $runner->attach($streamContainer, function () {
+            // ignore
+        }, $streamContainer->getIdentity());
+    }
+
     public function testIdentityConflict(): void
     {
         $this->expectStreamFactory();
@@ -81,6 +111,10 @@ class RunnerTest extends TestCase
         $runner->attach($streamContainer, function () {
             // ignore
         }, $streamContainer->getIdentity());
+
+        $this->expectStreamIsReadable()->setReturn(function () {
+            return true;
+        });
         $this->expectException(RunnerException::class);
         $this->expectExceptionMessage('Stream container with identity mock-stream-container already attached');
         $runner->attach($streamContainer, function () {


### PR DESCRIPTION
Possible fix for behavior indicated in #152 concerning identify conflicts.

As identity is generated using socket ports there should not be any conflict for active connections. However, if a socket is closed but not properly unregistered from the listener this may occur. 
I haven't found out what can cause closed sockets to remain registered. This PR rather adds a safeguard, checking if socket is readable and removes the previously registered if closed, so the conflict no longer occur.

Closing #152 