### PR TITLE
Fix connection not being detached

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,15 @@
 
  > PHP version `^8.1`
 
+### `3.7.2`
+
+ * Detach connection in failed handshake (@sirn-se)
+
+### `3.7.1`
+
+ * Fix spelling in class definitions (@carvefx)
+ * Detach connection if not usable (@sirn-se)
+
 ### `3.7.0`
 
  * Configuration class for various settings (@sirn-se)

--- a/src/Server.php
+++ b/src/Server.php
@@ -642,6 +642,7 @@ class Server implements IdentityInterface, LoggerAwareInterface, StreamContainer
             ]);
             $this->dispatch('connect', [$this, $connection, $request]);
         } catch (ExceptionInterface | StreamException $e) {
+            $this->runner->detach($connection->getIdentity());
             $connection->disconnect();
             throw new ConnectionFailureException("Server failed to accept: {$e->getMessage()}");
         }

--- a/tests/suites/server/HandshakeTest.php
+++ b/tests/suites/server/HandshakeTest.php
@@ -138,6 +138,7 @@ class HandshakeTest extends TestCase
         });
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamGetMetadata();
+        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
         $server->start();
 
@@ -181,6 +182,7 @@ class HandshakeTest extends TestCase
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 405 Method Not Allowed\r\n\r\n", $params[0]);
         });
+        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
         $server->start();
 
@@ -224,6 +226,7 @@ class HandshakeTest extends TestCase
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\n\r\n", $params[0]);
         });
+        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
         $server->start();
 
@@ -267,6 +270,7 @@ class HandshakeTest extends TestCase
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\n\r\n", $params[0]);
         });
+        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
         $server->start();
 
@@ -310,6 +314,7 @@ class HandshakeTest extends TestCase
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\nSec-WebSocket-Version: 13\r\n\r\n", $params[0]);
         });
+        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
         $server->start();
 
@@ -350,6 +355,7 @@ class HandshakeTest extends TestCase
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\n\r\n", $params[0]);
         });
+        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
         $server->start();
 
@@ -393,6 +399,7 @@ class HandshakeTest extends TestCase
         $this->expectSocketStreamWrite()->addAssert(function ($method, $params) {
             $this->assertEquals("HTTP/1.1 426 Upgrade Required\r\n\r\n", $params[0]);
         });
+        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
         $server->start();
 
@@ -438,6 +445,7 @@ class HandshakeTest extends TestCase
         });
         $this->expectSocketStreamIsConnected();
         $this->expectSocketStreamGetMetadata();
+        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
         $server->start();
 


### PR DESCRIPTION
When handshake failed, connection was closed but wasn't detached from the listener.