### PR TITLE
Fix disconnect not being dispatched on connection level error

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -605,6 +605,7 @@ class Server implements IdentityInterface, LoggerAwareInterface, StreamContainer
                         'message' => $e->getMessage(),
                     ]);
                     $this->dispatch('error', [$this, $connection, $e]);
+                    $this->dispatch('disconnect', [$this, $connection]);
                 } catch (CloseException $e) {
                     // Should close
                     $connection->close($e->getCloseStatus(), $e->getMessage());

--- a/tests/suites/server/ServerTest.php
+++ b/tests/suites/server/ServerTest.php
@@ -569,6 +569,41 @@ class ServerTest extends TestCase
         $server->disconnect();
     }
 
+    public function testRunConnectionClosedExceptionDispatchesDisconnect(): void
+    {
+        $this->expectWsServerCreate();
+        $server = new Server(8000, streamFactory: new StreamFactory());
+
+        $disconnected = [];
+        $server->onDisconnect(function ($server, $connection) use (&$disconnected) {
+            $disconnected[] = $connection->getIdentity();
+        });
+
+        $this->expectWsServerSetup(scheme: 'tcp', port: 8000);
+        $this->expectWsSelectConnections(['server/8000']);
+        $this->expectWsServerAccept();
+        $this->expectWsServerPerformHandshake();
+        $this->expectSocketStreamIsConnected();
+        $this->expectWsSelectConnections(['*/connection/8000/12345']);
+        $this->expectSocketStreamRead()->addAssert(function (string $method, array $params) {
+            $this->assertEquals(2, $params[0]);
+        })->setReturn(function () use ($server) {
+            $server->stop();
+            throw new ConnectionClosedException();
+        });
+        $this->expectStreamCollectionDetach();
+        $this->expectSocketStreamClose();
+        $server->start();
+
+        // Should be removed and dispatched as disconnected
+        $this->assertEquals(0, $server->getConnectionCount());
+        $this->assertEquals(['*/connection/8000/12345'], $disconnected);
+
+        $this->expectSocketServerClose();
+        $this->expectStreamCollectionDetach();
+        $server->disconnect();
+    }
+
     public function testRunServerException(): void
     {
         $this->expectWsServerCreate();


### PR DESCRIPTION
## Bug

When a connection dies with a `ConnectionLevelInterface` exception (e.g. `ConnectionClosedException` because a client closed the TCP stream without sending a close frame), the catch block in `Server::start()` detaches the connection and removes it from the connection list, but only dispatches `error` - never `disconnect`.

`Server::shutdown()` relies on exactly that event: with connections still open it clears all listeners and registers an `onDisconnect` callback as the only remaining path to stop the server. If the last connection dies on connection level, that callback never fires. The server then keeps running forever with `allowConnections = false` - the socket stays open, new connections are never accepted, and the tick listener that could retry the shutdown is gone as well.

Observed in production: clients (a Kubernetes readiness probe) close the TCP stream after the handshake without a websocket close frame. Whenever such a zombie connection was open at shutdown time, the server hung until an external supervisor killed the process.

Related: #87 / #88 fixed shutdown for the zero-connections case; this covers the remaining path. `Client.php` already dispatches `disconnect` in its `ConnectionLevelInterface` catch - this makes the server behave consistently.

## Fix

Dispatch `disconnect` after `error` in the `ConnectionLevelInterface` catch, matching the other two places that remove a connection.

## Tests

* New test `testRunConnectionClosedExceptionDispatchesDisconnect` - written first, fails on current master (connection removed, no `disconnect` dispatched), passes with the fix.
* Full suite green: 232 tests, 12054 assertions; phpcs and phpstan clean; coverage stays at 100% (1761/1761 lines).