### PR TITLE
Fix typos, remove redundant runner detach

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11,7 +11,7 @@
  * Configurable opcode/class mapping using OpcodeRegistry (@sirn-se)
  * onMessage() listener, triggered on all messages (@sirn-se)
  * Connections container class (@sirn-se)
- * Dispach onDisconnect on remote connection close (@srebb, @sirn-se)
+ * Dispatch onDisconnect on remote connection close (@srebb, @sirn-se)
  * Exceptions: ControlInterface on CloseException, ReconnectException (@sirn-se)
  * Exceptions: HandlerLevelInterface on BadUriException, ClientException, RunnerException, ServerException (@sirn-se)
  * Close status as int<0, 4999>|null (@sirn-se)

--- a/src/Exception/ControlInterface.php
+++ b/src/Exception/ControlInterface.php
@@ -9,7 +9,7 @@ namespace WebSocket\Exception;
 
 /**
  * WebSocket\Exception\ControlInterface interface.
- * Indicates that handler should perform some actio0n.
+ * Indicates that handler should perform some action.
  */
 interface ControlInterface extends ExceptionInterface
 {

--- a/src/Server.php
+++ b/src/Server.php
@@ -600,7 +600,6 @@ class Server implements IdentityInterface, LoggerAwareInterface, StreamContainer
                     $this->dispatch('error', [$this, $connection, $e]);
                 } catch (ConnectionLevelInterface $e) {
                     // Error, disconnect connection
-                    $this->runner->detach($key);
                     $this->connections->detach($key);
                     $this->disconnectConnection($connection);
                     $this->configuration->getLogger()->error("[{scope}] {message}", [

--- a/tests/suites/server/ServerTest.php
+++ b/tests/suites/server/ServerTest.php
@@ -561,8 +561,8 @@ class ServerTest extends TestCase
             $server->stop();
             throw new ConnectionClosedException();
         });
-        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
+        $this->expectStreamCollectionDetach();
         $server->start();
 
         // Should be closed
@@ -598,8 +598,8 @@ class ServerTest extends TestCase
             $server->stop();
             throw new ConnectionClosedException();
         });
-        $this->expectStreamCollectionDetach();
         $this->expectSocketStreamClose();
+        $this->expectStreamCollectionDetach();
         $server->start();
 
         // Should be removed and dispatched as disconnected


### PR DESCRIPTION
Drop explicit runner detach in ConnectionLevelInterface catch cause disconnectConnection() already detaches.
Test expectations updated for the changed operation order (stream now closes before collection detach).